### PR TITLE
feat: Add stop hooks for quality gates

### DIFF
--- a/framework/hooks/validate-implementation.sh
+++ b/framework/hooks/validate-implementation.sh
@@ -10,12 +10,10 @@ IMPL_FILE="$PROJECT_DIR/.claude/.csf/implementation-summary.md"
 
 [ ! -f "$SPEC_FILE" ] || [ ! -f "$IMPL_FILE" ] && exit 0
 
-CRITERIA=$(grep -i "^\- \[" "$SPEC_FILE" 2>/dev/null | head -5)
+CRITERIA=$(grep -i "^\- \[" "$SPEC_FILE" 2>/dev/null)
 [ -z "$CRITERIA" ] && exit 0
 
 UNCHECKED=$(echo "$CRITERIA" | grep -c "\[ \]" || echo "0")
 if [ "$UNCHECKED" -gt 0 ]; then
   echo "{\"decision\":\"block\",\"reason\":\"$UNCHECKED acceptance criteria unchecked in spec\"}"
-else
-  echo "{\"decision\":\"approve\",\"reason\":\"Implementation aligns with spec\"}"
 fi

--- a/framework/hooks/validate-spec.sh
+++ b/framework/hooks/validate-spec.sh
@@ -17,6 +17,4 @@ grep -qi "risk" "$SPEC_FILE" || MISSING="$MISSING risks,"
 if [ -n "$MISSING" ]; then
   MISSING="${MISSING%,}"
   echo "{\"decision\":\"block\",\"reason\":\"Spec missing sections:$MISSING\"}"
-else
-  echo "{\"decision\":\"approve\",\"reason\":\"Spec structure valid\"}"
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -320,7 +320,7 @@ EOF
             # Ensure hooks.Stop exists as array
             .hooks.Stop = (.hooks.Stop // [])
             # Remove existing CSF hooks (containing /hooks/csf/)
-            | .hooks.Stop = [.hooks.Stop[] | select(.hooks | all(.command | contains("/hooks/csf/") | not))]
+            | .hooks.Stop = [.hooks.Stop[] | select(.hooks | all((.command // "") | contains("/hooks/csf/") | not))]
             # Add our CSF hooks
             | .hooks.Stop += [$csf_hooks]
         ' "$settings_file" > "$temp_file"


### PR DESCRIPTION
## Summary

- Adds native Claude Code stop hooks to validate work before returning control to user
- Replaces manual `validate-framework.sh` invocation with automatic quality gates
- Hooks installed to `~/.claude/hooks/csf/` via install script

Closes #50

## Changes

| File | Description |
|------|-------------|
| `framework/hooks/validate-spec.sh` | Validates spec.md has required sections (scope, criteria, risks) |
| `framework/hooks/validate-implementation.sh` | Validates implementation against spec acceptance criteria |
| `scripts/install.sh` | Installs hooks + merges settings.json |

## How It Works

1. **Installation**: Hooks copied to `~/.claude/hooks/csf/`
2. **Settings merge**: `jq`-based merge adds hooks to `~/.claude/settings.json` while preserving existing settings
3. **At session end**: Stop hooks validate current state and block with actionable feedback if issues found

## Test Plan

- [x] Fresh install creates settings.json with Stop hooks
- [x] Update preserves existing user settings
- [x] Idempotent - re-running doesn't duplicate hooks
- [x] validate-spec.sh returns correct JSON decisions
- [x] Hooks fail open when files missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)