### PR TITLE
fix: Replace GNU-only head -n -5 with POSIX-compatible arithmetic

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -206,7 +206,7 @@ if [ "$MODE" = "update" ]; then
     if [ -d "$BACKUP_BASE_DIR" ]; then
         BACKUP_COUNT=$(find "$BACKUP_BASE_DIR" -maxdepth 1 -type d -name "20*" 2>/dev/null | wc -l)
         if [ "$BACKUP_COUNT" -gt 5 ]; then
-            find "$BACKUP_BASE_DIR" -maxdepth 1 -type d -name "20*" 2>/dev/null | sort | head -n -5 | while read -r old_backup; do
+            find "$BACKUP_BASE_DIR" -maxdepth 1 -type d -name "20*" 2>/dev/null | sort | head -n $(( BACKUP_COUNT - 5 )) | while read -r old_backup; do
                 rm -rf "$old_backup"
                 echo "  🗑️ Removed old backup: $(basename "$old_backup")"
             done


### PR DESCRIPTION
## Summary
- Fixes #70: `head -n -5` is GNU-only and fails silently on macOS (BSD `head`)
- Replaced with `head -n $(( BACKUP_COUNT - 5 ))` which is POSIX-compatible
- The existing `BACKUP_COUNT > 5` guard ensures the arithmetic always produces a positive number

## Test plan
- [ ] Verify backup cleanup works on macOS (BSD `head`)
- [ ] Verify backup cleanup works on Linux (GNU `head`)
- [ ] Confirm existing bats tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)