### PR TITLE
fix: Use individual file paths in plugin.json for CLI compatibility

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,24 @@
   "name": "claude-spec-first",
   "version": "0.29.0",
   "description": "Minimalist spec-first development workflow",
-  "agents": ["./framework/agents"],
-  "skills": ["./framework/skills"],
+  "agents": [
+    "./framework/agents/analyze-artifacts.md",
+    "./framework/agents/analyze-existing-docs.md",
+    "./framework/agents/analyze-implementation.md",
+    "./framework/agents/create-criteria.md",
+    "./framework/agents/create-technical-docs.md",
+    "./framework/agents/create-user-docs.md",
+    "./framework/agents/define-scope.md",
+    "./framework/agents/identify-risks.md",
+    "./framework/agents/implement-minimal.md",
+    "./framework/agents/integrate-docs.md",
+    "./framework/agents/manage-spec-directory.md",
+    "./framework/agents/synthesize-spec.md"
+  ],
+  "skills": [
+    "./framework/skills/document",
+    "./framework/skills/implement",
+    "./framework/skills/spec"
+  ],
   "hooks": "./framework/hooks/hooks.json"
 }

--- a/framework/validate-framework.sh
+++ b/framework/validate-framework.sh
@@ -291,7 +291,10 @@ fi
 if [ -f "$MANIFEST_FILE" ] && command -v jq &>/dev/null && jq empty "$MANIFEST_FILE" 2>/dev/null; then
     REQUIRED_AGENTS=()
     while IFS= read -r agent; do
-        if [[ "$agent" == ./* ]]; then
+        if [[ "$agent" == *.md ]]; then
+            # Individual file path — extract name from basename
+            REQUIRED_AGENTS+=("$(basename "$agent" .md)")
+        elif [[ "$agent" == ./* ]]; then
             # Directory path — discover agent .md files within it
             while IFS= read -r agent_file; do
                 REQUIRED_AGENTS+=("$(basename "$agent_file" .md)")
@@ -303,12 +306,8 @@ if [ -f "$MANIFEST_FILE" ] && command -v jq &>/dev/null && jq empty "$MANIFEST_F
     REQUIRED_SKILLS=()
     while IFS= read -r skill; do
         if [[ "$skill" == ./* ]]; then
-            # Directory path — discover skill subdirectories containing SKILL.md
-            while IFS= read -r skill_dir; do
-                if [ -f "$skill_dir/SKILL.md" ]; then
-                    REQUIRED_SKILLS+=("$(basename "$skill_dir")")
-                fi
-            done < <(find "$skill" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+            # Path entry — extract skill name from basename
+            REQUIRED_SKILLS+=("$(basename "$skill")")
         else
             REQUIRED_SKILLS+=("$skill")
         fi

--- a/tests/integration/plugin-validation.bats
+++ b/tests/integration/plugin-validation.bats
@@ -27,13 +27,15 @@ assert 'hooks' in data, 'missing hooks'
     manifest_agents=$(cat "$PROJECT_ROOT/.claude-plugin/plugin.json" | python3 -c "
 import sys, json, os, glob
 data = json.load(sys.stdin)
-names = []
+names = set()
 for entry in data['agents']:
-    if entry.startswith('./'):
+    if entry.endswith('.md'):
+        names.add(os.path.splitext(os.path.basename(entry))[0])
+    elif entry.startswith('./'):
         path = os.path.join('$PROJECT_ROOT', entry)
-        names.extend(os.path.splitext(os.path.basename(f))[0] for f in sorted(glob.glob(os.path.join(path, '*.md'))))
+        names.update(os.path.splitext(os.path.basename(f))[0] for f in glob.glob(os.path.join(path, '*.md')))
     else:
-        names.append(entry)
+        names.add(entry)
 print('\n'.join(sorted(names)))
 ")
 
@@ -48,13 +50,16 @@ print('\n'.join(sorted(names)))
     manifest_skills=$(cat "$PROJECT_ROOT/.claude-plugin/plugin.json" | python3 -c "
 import sys, json, os
 data = json.load(sys.stdin)
-names = []
+names = set()
 for entry in data['skills']:
     if entry.startswith('./'):
         path = os.path.join('$PROJECT_ROOT', entry)
-        names.extend(os.path.basename(d) for d in sorted(os.listdir(path)) if os.path.isdir(os.path.join(path, d)))
+        if os.path.isdir(path) and os.path.exists(os.path.join(path, 'SKILL.md')):
+            names.add(os.path.basename(entry))
+        elif os.path.isdir(path):
+            names.update(d for d in os.listdir(path) if os.path.isdir(os.path.join(path, d)))
     else:
-        names.append(entry)
+        names.add(entry)
 print('\n'.join(sorted(names)))
 ")
 


### PR DESCRIPTION
## Summary
- Directory paths (`["./framework/agents"]`) are rejected by Claude Code CLI validator with `agents: Invalid input`
- Individual file paths work — matches format used by [dotnet-skills](https://github.com/Aaronontheweb/dotnet-skills) and other working plugins
- Updates validate-framework.sh and tests to handle both formats

## Context
- `claude plugin install claude-spec-first` was failing with validation error
- Root cause: CLI validator expects individual `.md` file paths for agents, not directory paths
- The [manifest-reference docs](https://github.com/anthropics/claude-plugins-official/blob/main/plugins/plugin-dev/skills/plugin-structure/references/manifest-reference.md) show directory paths, but the actual validator rejects them

## Marketplace auto-sync
Already configured — `release-please-config.json` has `marketplace.json` in `extra-files` with the correct jsonpath. Next release will bump it automatically.

## Test plan
- [ ] `bash framework/validate-framework.sh` passes (99/0/1)
- [ ] CI checks pass
- [ ] `claude plugin install claude-spec-first` succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)