### PR TITLE
fix: Include all commit types in release-please changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -24,8 +24,8 @@
     {"type": "feat", "section": "Features"},
     {"type": "fix", "section": "Bug Fixes"},
     {"type": "perf", "section": "Performance"},
-    {"type": "refactor", "section": "Code Refactoring", "hidden": true},
-    {"type": "docs", "section": "Documentation", "hidden": true},
-    {"type": "chore", "section": "Miscellaneous", "hidden": true}
+    {"type": "refactor", "section": "Code Refactoring"},
+    {"type": "docs", "section": "Documentation"},
+    {"type": "chore", "section": "Miscellaneous"}
   ]
 }


### PR DESCRIPTION
## Summary
- Remove `hidden: true` from refactor, docs, and chore changelog sections in release-please config
- All conventional commit types now trigger a release PR and appear in the changelog

## Test plan
- [ ] Merge a refactor/docs/chore commit and verify release-please creates a release PR

🤖 Generated with [Claude Code](https://claude.ai/code)