### PR TITLE
fix: align marketplace plugin name with plugin.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "plugins": [
     {
-      "name": "claude-spec-first",
+      "name": "csf",
       "source": {
         "source": "github",
         "repo": "bitcraft-apps/claude-spec-first"


### PR DESCRIPTION
## Summary
- Marketplace `plugins[0].name` was `"claude-spec-first"` while `plugin.json` declares `"csf"`
- Claude Code's update mechanism reads the plugin name from `plugin.json` and searches the marketplace listing — the mismatch caused `"Plugin csf not found in marketplace"` on update
- Aligned marketplace listing to `"csf"` to match the plugin's identity (skill prefix `/csf:*`, working dir `.claude/.csf/`)

## Test plan
- [ ] Install plugin fresh from marketplace — verify it registers correctly
- [ ] Use "Update now" in plugin UI — verify it no longer errors with "Plugin csf not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)