### PR TITLE
chore: force next release as 1.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "bump-minor-pre-major": true,
+      "release-as": "1.0.0",
       "changelog-path": "CHANGELOG.md",
       "version-file": "VERSION",
       "extra-files": [


### PR DESCRIPTION
## Summary
- Replace `bump-minor-pre-major` with `release-as: 1.0.0` in release-please config
- This will cause release-please to regenerate PR #151 targeting v1.0.0 instead of v0.32.0
- **Remember to remove `release-as` after the 1.0.0 release** so future versions auto-increment

🤖 Generated with [Claude Code](https://claude.com/claude-code)