### PR TITLE
fix: remove one-time release bootstrapping config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,9 +1,7 @@
 {
-  "bootstrap-sha": "df7271678bf29970ffc8f487617dd456e85e7ac3",
   "packages": {
     ".": {
       "release-type": "simple",
-      "release-as": "1.0.0",
       "changelog-path": "CHANGELOG.md",
       "version-file": "VERSION",
       "extra-files": [


### PR DESCRIPTION
## Summary
- Remove `release-as: 1.0.0` that was pinning every release to 1.0.0
- Remove `bootstrap-sha` that was only needed for initial release setup

## Test plan
- [ ] Merge and verify next release-please PR increments version normally (e.g., 1.0.1 or 1.1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)