### PR TITLE
fix: add completion instructions to synthesize-spec agent

### DIFF
--- a/agents/synthesize-spec.md
+++ b/agents/synthesize-spec.md
@@ -16,3 +16,7 @@ Rules:
 - Focus on what to build, not how
 - Exclude enterprise features unless explicitly requested
 - Challenge complexity at every step
+
+Completion:
+- Do NOT suggest next commands other than `/sf:implement`
+- Say: "Spec written to `{output path}`. Run `/sf:implement` to build it."


### PR DESCRIPTION
## Summary
- Adds explicit `Completion:` section to `agents/synthesize-spec.md` so the agent suggests `/sf:implement` instead of hallucinating a nonexistent `/sf:plan` command after spec generation

## Test plan
- [ ] Run `/sf:spec` end-to-end and verify output references `/sf:implement`, not `/sf:plan`
- [ ] Verify `grep -r "sf:plan" agents/ skills/` returns zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)