### PR TITLE
chore: add Dependabot for GitHub Actions and submodule updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly schedules for `github-actions` and `gitsubmodule` ecosystems
- Creates `dependencies` label (already done via `gh label create`)
- Uses `chore(deps)` commit prefix compatible with release-please

Closes #162

## Test plan
- [ ] Verify `.github/dependabot.yml` is valid by checking the repo's Dependabot insights page after merge
- [ ] Confirm `dependencies` label appears on future Dependabot PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)