### PR TITLE
fix: add failure handling to manage-spec-directory

### DIFF
--- a/agents/manage-spec-directory.md
+++ b/agents/manage-spec-directory.md
@@ -17,8 +17,9 @@ while [ "$PROJECT_ROOT" != "/" ]; do
     [ -f "$PROJECT_ROOT/CLAUDE.md" ] && break
     PROJECT_ROOT="$(dirname "$PROJECT_ROOT")"
 done
+[ "$PROJECT_ROOT" = "/" ] && echo "Error: CLAUDE.md not found in any parent directory" >&2 && exit 1
 SF_DIR="$PROJECT_ROOT/.claude/.sf"
-mkdir -p "$SF_DIR"
+mkdir -p "$SF_DIR" 2>/dev/null || { echo "Error: Cannot create or write to $SF_DIR" >&2; exit 1; }
 [ -d "$PROJECT_ROOT/.git" ] && [ -f "$PROJECT_ROOT/.gitignore" ] && ! grep -qF '.claude/.sf/' "$PROJECT_ROOT/.gitignore" && echo '.claude/.sf/' >> "$PROJECT_ROOT/.gitignore"
 if [ -f "$SF_DIR/mode" ]; then
     MODE=$(cat "$SF_DIR/mode")

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -54,6 +54,7 @@ After directory setup and clarification (if needed), run agents:
 
 **Pre-execution:**
 - Task: manage-spec-directory (maxTurns: 3) (reads mode from $SF_DIR/mode file)
+- **If manage-spec-directory fails (non-zero exit), halt immediately — do not run downstream agents.**
 
 **Batch 1 (Parallel):**
 - Task: define-scope (maxTurns: 6) with requirements: $ARGUMENTS

--- a/tests/integration/directory-isolation.bats
+++ b/tests/integration/directory-isolation.bats
@@ -48,6 +48,28 @@ teardown() {
     grep -q "rm -f.*mode" "$agent_file"
 }
 
+@test "manage-spec-directory agent validates CLAUDE.md exists" {
+    local agent_file="$PROJECT_ROOT/agents/manage-spec-directory.md"
+
+    # Check for CLAUDE.md existence validation with non-zero exit
+    grep -q 'CLAUDE.md not found' "$agent_file"
+    grep -q 'exit 1' "$agent_file"
+}
+
+@test "manage-spec-directory agent validates directory is writable" {
+    local agent_file="$PROJECT_ROOT/agents/manage-spec-directory.md"
+
+    # Check for writable directory validation with stderr output
+    grep -q 'Cannot create or write to' "$agent_file"
+}
+
+@test "spec skill halts on manage-spec-directory failure" {
+    local skill_file="$PROJECT_ROOT/skills/spec/SKILL.md"
+
+    # Check that spec skill documents halting on failure
+    grep -q 'manage-spec-directory fails.*halt' "$skill_file"
+}
+
 @test "spec skill includes directory management step" {
     # Check spec skill references the new agent
     grep -q "manage-spec-directory" "$PROJECT_ROOT/skills/spec/SKILL.md"


### PR DESCRIPTION
## Summary
- Add input validation to `manage-spec-directory` agent: exits non-zero with stderr message when CLAUDE.md is missing or `.claude/.sf/` is unwritable
- Add error propagation in spec skill: halts pipeline when manage-spec-directory fails
- Add 3 BATS tests covering the new validation checks

Closes #174

## Test plan
- [x] All 10 directory-isolation BATS tests pass (including 3 new)
- [ ] Run `/sf:spec` in a directory without CLAUDE.md — verify error message and non-zero exit
- [ ] Run `/sf:spec` normally — verify existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)