### PR TITLE
docs: add token usage guidance to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ Updated: docs/middleware.md (added rate limiter section)
 
 Each command orchestrates specialized agents that run in parallel where possible. The spec is the contract between define and implement — no spec, no code.
 
+## Token Usage
+
+Typical ranges per phase (example: small CLI tool, ~500 lines):
+
+| Phase | Input tokens | Output tokens |
+|-------|-------------|---------------|
+| spec | 10k–30k | 2k–6k |
+| implement | 30k–120k | 5k–30k |
+| document | 20k–60k | 3k–10k |
+
+Actual usage varies with codebase size, feature complexity, and iteration count. For current pricing, see [Claude pricing](https://www.anthropic.com/pricing).
+
 ## Command Reference
 
 | Command | Purpose |


### PR DESCRIPTION
## Summary
- Adds a "Token Usage" subsection to the README with per-phase token ranges (spec, implement, document)
- Anchored to a concrete example (small CLI tool, ~500 lines) for context
- Links to Claude pricing page instead of including dollar amounts

Closes #186

## Test plan
- [ ] Verify section appears between "How it works" and "Command Reference"
- [ ] Confirm section is under 100 words
- [ ] Confirm no absolute pricing numbers are included
- [ ] Verify pricing link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)