### PR TITLE
fix: move maxTurns from skill prose to agent frontmatter

### DIFF
--- a/agents/analyze-artifacts.md
+++ b/agents/analyze-artifacts.md
@@ -3,6 +3,7 @@ name: analyze-artifacts
 description: Read and parse SF artifacts (spec, criteria, risks). Use when documentation needs context from the spec phase.
 tools: Read
 model: haiku
+maxTurns: 6
 ---
 
 # Artifact Analyzer

--- a/agents/analyze-existing-docs.md
+++ b/agents/analyze-existing-docs.md
@@ -3,6 +3,7 @@ name: analyze-existing-docs
 description: Scan existing docs and produce an inventory manifest. Use when determining which docs to update vs create.
 tools: Read, Glob
 model: haiku
+maxTurns: 6
 ---
 
 # Documentation Inventory Scanner

--- a/agents/analyze-implementation.md
+++ b/agents/analyze-implementation.md
@@ -3,6 +3,7 @@ name: analyze-implementation
 description: Analyze code structure and implementation patterns. Use when documentation needs to reflect actual code changes.
 tools: Read, Grep, Glob, LSP
 model: haiku
+maxTurns: 10
 ---
 
 # Implementation Analyzer

--- a/agents/create-criteria.md
+++ b/agents/create-criteria.md
@@ -3,6 +3,7 @@ name: create-criteria
 description: Generate testable acceptance criteria. Use when defining pass/fail conditions for a spec.
 tools: Write
 model: haiku
+maxTurns: 6
 ---
 
 # Acceptance Criteria

--- a/agents/create-technical-docs.md
+++ b/agents/create-technical-docs.md
@@ -2,6 +2,7 @@
 name: create-technical-docs
 description: Generate minimal developer documentation. Use when a change needs technical reference or API docs.
 tools: Read, Write
+maxTurns: 15
 ---
 
 # Technical Documentation Generator

--- a/agents/create-user-docs.md
+++ b/agents/create-user-docs.md
@@ -2,6 +2,7 @@
 name: create-user-docs
 description: Generate minimal user-facing documentation. Use when a change affects user-visible behavior or workflows.
 tools: Read, Write
+maxTurns: 15
 ---
 
 # User Documentation Generator

--- a/agents/define-scope.md
+++ b/agents/define-scope.md
@@ -3,6 +3,7 @@ name: define-scope
 description: Define MVP boundaries and scope. Use when decomposing requirements into the narrowest viable change.
 tools: Write
 model: haiku
+maxTurns: 6
 ---
 
 # Scope Definition

--- a/agents/identify-risks.md
+++ b/agents/identify-risks.md
@@ -3,6 +3,7 @@ name: identify-risks
 description: Identify blockers, risks, and edge cases. Use when assessing what could go wrong before implementation.
 tools: Write
 model: haiku
+maxTurns: 6
 ---
 
 # Risk Identification

--- a/agents/implement-minimal.md
+++ b/agents/implement-minimal.md
@@ -2,6 +2,7 @@
 name: implement-minimal
 description: Write the simplest working implementation. Use when executing code changes from a finalized spec.
 tools: Read, Write, Edit, MultiEdit, Bash
+maxTurns: 25
 ---
 
 # Minimal Implementation

--- a/agents/integrate-docs.md
+++ b/agents/integrate-docs.md
@@ -2,6 +2,7 @@
 name: integrate-docs
 description: Merge generated docs into existing project files. Use when doc drafts are ready to integrate into the repo.
 tools: Read, Write, Edit, MultiEdit, Glob
+maxTurns: 15
 ---
 
 # Documentation Integrator

--- a/agents/manage-spec-directory.md
+++ b/agents/manage-spec-directory.md
@@ -3,6 +3,7 @@ name: manage-spec-directory
 description: Create and manage spec output directories. Use when initializing or resetting the SF workspace.
 tools: Bash
 model: haiku
+maxTurns: 3
 ---
 
 # Spec Directory Manager

--- a/agents/synthesize-spec.md
+++ b/agents/synthesize-spec.md
@@ -2,6 +2,7 @@
 name: synthesize-spec
 description: Combine research into a minimal actionable spec. Use when scope, criteria, and risks are ready to merge.
 tools: Read, Write
+maxTurns: 12
 ---
 
 # Specification Synthesizer

--- a/docs/technical-reference.md
+++ b/docs/technical-reference.md
@@ -14,9 +14,7 @@ Commands are defined as skills in `skills/`. Each `SKILL.md` is the source of tr
 
 ## Agents
 
-Agent files live in `agents/`. Each has YAML frontmatter: `name`, `description`, `tools` (required), `model` (optional, only `haiku`). See agent files for details — they are the source of truth.
-
-Agent turn limits (`maxTurns`) are set in skill files, not agent frontmatter.
+Agent files live in `agents/`. Each has YAML frontmatter: `name`, `description`, `tools` (required), `model` (optional, only `haiku`), `maxTurns` (optional turn limit). See agent files for details — they are the source of truth.
 
 ## Integration Contracts
 
@@ -94,7 +92,7 @@ Current events: `Stop` (2 hooks: validate-spec, validate-implementation), `Subag
 
 ## Setup
 
-- Claude Code CLI with `Agent` tool support (`subagent_type`, `maxTurns`)
+- Claude Code CLI with `Agent` tool support (`subagent_type`)
 - Haiku model access for research agents
 - LSP is optional — `analyze-implementation` falls back to Grep/Glob
 

--- a/skills/document/SKILL.md
+++ b/skills/document/SKILL.md
@@ -32,9 +32,9 @@ Creates minimal, proportional documentation. Match doc weight to change weight.
 After input resolution, run agents in 3 batches:
 
 **Batch 1 (Parallel):**
-- Task: analyze-artifacts (maxTurns: 6) with requirements: $ARTIFACT_PATHS
-- Task: analyze-implementation (maxTurns: 10) with requirements: $IMPLEMENTATION_PATHS
-- Task: analyze-existing-docs (maxTurns: 6) (scans project for existing documentation inventory)
+- Task: analyze-artifacts with requirements: $ARTIFACT_PATHS
+- Task: analyze-implementation with requirements: $IMPLEMENTATION_PATHS
+- Task: analyze-existing-docs (scans project for existing documentation inventory)
 
 **Gate 1 — Post-Analysis:**
 Check that each output file exists:
@@ -45,8 +45,8 @@ Check that each output file exists:
 Missing file = agent failed to run → halt pipeline, report which file(s) are missing, preserve existing output for inspection. Empty or whitespace-only file = valid "no docs needed" signal → pass. Write gate results to `$SF_DIR/research/gate-analysis.md` (pass/fail per file, warnings for files under 5 lines).
 
 **Batch 2 (Parallel):**
-- Task: create-technical-docs (maxTurns: 15) (reads $SF_DIR/research/artifacts-summary.md, $SF_DIR/research/implementation-summary.md)
-- Task: create-user-docs (maxTurns: 15) (reads $SF_DIR/research/artifacts-summary.md, $SF_DIR/research/implementation-summary.md)
+- Task: create-technical-docs (reads $SF_DIR/research/artifacts-summary.md, $SF_DIR/research/implementation-summary.md)
+- Task: create-user-docs (reads $SF_DIR/research/artifacts-summary.md, $SF_DIR/research/implementation-summary.md)
 
 **Gate 2 — Post-Generation:**
 For each generated doc, verify:
@@ -56,7 +56,7 @@ For each generated doc, verify:
 Block on: placeholder-only content. Empty files are valid — they mean the agent correctly determined no docs were needed. Write gate results to `$SF_DIR/research/gate-generation.md`.
 
 **Batch 3:**
-- Task: integrate-docs (maxTurns: 15) (reads docs-inventory.md to update existing files or create new ones)
+- Task: integrate-docs (reads docs-inventory.md to update existing files or create new ones)
 
 **Gate 3 — Post-Integration:**
 Verify integration completed. If no docs were updated or created, that's valid — report "no documentation changes needed" and finish cleanly. Write gate results to `$SF_DIR/research/gate-integration.md`.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -34,12 +34,12 @@ Creates minimal implementation following existing patterns.
 After input resolution, run sequential agents:
 
 **Step 1: Learn**
-- Use Agent tool with subagent_type="Explore", maxTurns=10 to find similar patterns in the codebase for: $SPECIFICATION (request "medium" thoroughness in the prompt)
+- Use Agent tool with subagent_type="Explore" to find similar patterns in the codebase for: $SPECIFICATION (request "medium" thoroughness in the prompt)
 - Save findings to `.claude/.sf/research/pattern-example.md`
 
 **Step 2: Implement**
-- If ISOLATE is true: Task: implement-minimal (maxTurns: 25) with spec: $SPECIFICATION, isolation: "worktree"
-- Else: Task: implement-minimal (maxTurns: 25) with spec: $SPECIFICATION
+- If ISOLATE is true: Task: implement-minimal with spec: $SPECIFICATION, isolation: "worktree"
+- Else: Task: implement-minimal with spec: $SPECIFICATION
 
 Output: Implementation + `.claude/.sf/implementation-summary.md`
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -53,16 +53,16 @@ Else:
 After directory setup and clarification (if needed), run agents:
 
 **Pre-execution:**
-- Task: manage-spec-directory (maxTurns: 3) (reads mode from $SF_DIR/mode file)
+- Task: manage-spec-directory (reads mode from $SF_DIR/mode file)
 - **If manage-spec-directory fails (non-zero exit), halt immediately — do not run downstream agents.**
 
 **Batch 1 (Parallel):**
-- Task: define-scope (maxTurns: 6) with requirements: $ARGUMENTS
-- Task: create-criteria (maxTurns: 6) with requirements: $ARGUMENTS
-- Task: identify-risks (maxTurns: 6) with requirements: $ARGUMENTS
+- Task: define-scope with requirements: $ARGUMENTS
+- Task: create-criteria with requirements: $ARGUMENTS
+- Task: identify-risks with requirements: $ARGUMENTS
 
 **Batch 2:**
-- Task: synthesize-spec (maxTurns: 12) to combine all research, following the structure in `${CLAUDE_SKILL_DIR}/spec-template.md`
+- Task: synthesize-spec to combine all research, following the structure in `${CLAUDE_SKILL_DIR}/spec-template.md`
 
 Output: `$SF_DIR/spec.md` (direct file or symlink to timestamped spec)
 


### PR DESCRIPTION
## Problem

Skill files stated subagent turn limits in prose, for example `- Task: define-scope (maxTurns: 6)`.
`maxTurns` is a subagent frontmatter field. It is not a parameter of the Agent tool.
The model cannot apply the prose numbers, so the limits had no effect.

## Changes

- Added one `maxTurns:` key to the frontmatter of each of the 12 files in `agents/`.
- Removed every `(maxTurns: N)` prose fragment from the 3 skill files.
- Removed `, maxTurns=10` from the `Explore` call in `skills/implement/SKILL.md`.
  `Explore` is built in and has no file in `agents/`, so its limit cannot move to
  frontmatter. The fragment had no effect there either.
- `docs/technical-reference.md`: merged `maxTurns` into the frontmatter field list,
  deleted the line that said the opposite, and removed `maxTurns` from the Agent tool
  parameter list.

`CHANGELOG.md` is untouched. No turn-limit value changed.

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)