### PR TITLE
refactor: make validate-implementation guard explicit

### DIFF
--- a/hooks/validate-implementation.sh
+++ b/hooks/validate-implementation.sh
@@ -8,7 +8,7 @@ PROJECT_DIR=$(echo "$INPUT" | jq -r '.cwd // ""')
 SPEC_FILE="$PROJECT_DIR/.claude/.sf/spec.md"
 IMPL_FILE="$PROJECT_DIR/.claude/.sf/implementation-summary.md"
 
-[ ! -f "$SPEC_FILE" ] || [ ! -f "$IMPL_FILE" ] && exit 0
+if [ ! -f "$SPEC_FILE" ] || [ ! -f "$IMPL_FILE" ]; then exit 0; fi
 
 CRITERIA=$(grep -i "^\- \[" "$SPEC_FILE" 2>/dev/null)
 [ -z "$CRITERIA" ] && exit 0

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,6 +15,7 @@ tests/
 ├── integration/                 # Integration tests
 │   ├── directory-isolation.bats # Spec directory isolation
 │   ├── framework.bats           # Framework structure tests
+│   ├── hooks.bats               # Hook execution and output
 │   ├── plugin-validation.bats   # Plugin artifact validation
 │   └── workflow.bats            # Workflow integration
 │
@@ -127,6 +128,7 @@ bats e2e/                           # All E2E tests
 **Files**:
 - `directory-isolation.bats`: Spec directory isolation
 - `framework.bats`: Framework structure and validation
+- `hooks.bats`: Hook execution and output (requires BATS 1.5.0 or later)
 - `plugin-validation.bats`: Plugin artifact validation (requires `python3`)
 - `workflow.bats`: Workflow integration
 
@@ -331,6 +333,22 @@ teardown() {
     [[ "$output" == *"expected content"* ]]
 }
 ```
+
+**Hook Tests:**
+
+Hooks read a JSON payload on stdin and write a decision to stdout. To test a hook:
+
+1. **Make a Temporary Directory**: Create `.claude/.sf/` in it during `setup()`
+2. **Write Fixtures**: Add the files the hook reads, for example `spec.md` and `implementation-summary.md`
+3. **Send the Payload**: Point the `cwd` field at the temporary directory
+4. **Separate stderr**: Use `run --separate-stderr` to keep stderr out of `$output`
+5. **Clean Up**: Remove the temporary directory in `teardown()`
+
+```bash
+run --separate-stderr bash "$HOOK" <<< "{\"cwd\":\"$TEST_DIR\",\"stop_hook_active\":false}"
+```
+
+The test runner finds `tests/integration/*.bats` automatically. A new file needs no registration. See `tests/integration/hooks.bats` for a full example.
 
 ### Debugging Failed Tests
 

--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+
+# Hook Integration Tests
+# Tests hooks/validate-implementation.sh against JSON payloads on stdin
+
+bats_require_minimum_version 1.5.0
+
+PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+export PROJECT_ROOT
+
+HOOK="$PROJECT_ROOT/hooks/validate-implementation.sh"
+export HOOK
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    export TEST_DIR
+    mkdir -p "$TEST_DIR/.claude/.sf"
+}
+
+teardown() {
+    [ -n "$TEST_DIR" ] && rm -rf "$TEST_DIR"
+}
+
+# Runs the hook with a payload that points at TEST_DIR.
+# Keeps stderr out of $output. Line 17 of the hook prints a shell error
+# when the spec has no unchecked criteria. That refactor is out of scope.
+run_hook() {
+    local active="${1:-false}"
+    run --separate-stderr bash "$HOOK" <<< "{\"cwd\":\"$TEST_DIR\",\"stop_hook_active\":$active}"
+}
+
+write_spec() {
+    printf '%s\n' "$@" > "$TEST_DIR/.claude/.sf/spec.md"
+}
+
+write_impl() {
+    echo "summary" > "$TEST_DIR/.claude/.sf/implementation-summary.md"
+}
+
+# --- Guard: missing files exit early ---
+
+@test "spec missing and implementation present exits 0 with no output" {
+    write_impl
+    run_hook
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "spec present and implementation missing exits 0 with no output" {
+    write_spec "- [ ] unchecked criterion"
+    run_hook
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "both files missing exits 0 with no output" {
+    run_hook
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# --- Decision output ---
+
+@test "unchecked criterion blocks" {
+    write_spec "- [ ] unchecked criterion"
+    write_impl
+    run_hook
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"decision":"block"'* ]]
+    [[ "$output" == *"1 acceptance criteria unchecked"* ]]
+}
+
+@test "all criteria checked produces no decision" {
+    write_spec "- [x] done" "- [x] also done"
+    write_impl
+    run_hook
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "spec with no criteria produces no decision" {
+    write_spec "# Spec" "No criteria here."
+    write_impl
+    run_hook
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# --- Re-entry guard ---
+
+@test "stop_hook_active true exits 0 with no output" {
+    write_spec "- [ ] unchecked criterion"
+    write_impl
+    run_hook true
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# --- Static checks ---
+
+@test "hook has no syntax error" {
+    run bash -n "$HOOK"
+    [ "$status" -eq 0 ]
+}
+
+@test "hook guard uses an explicit if block" {
+    run grep -c 'if \[ ! -f "\$SPEC_FILE" \] || \[ ! -f "\$IMPL_FILE" \]; then exit 0; fi' "$HOOK"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 1 ]
+}


### PR DESCRIPTION
Closes #208

## What changed

`hooks/validate-implementation.sh` line 11:

```diff
-[ ! -f "$SPEC_FILE" ] || [ ! -f "$IMPL_FILE" ] && exit 0
+if [ ! -f "$SPEC_FILE" ] || [ ! -f "$IMPL_FILE" ]; then exit 0; fi
```

`tests/integration/hooks.bats` is new. It is the first test for any hook. It builds a
temporary project directory, writes `.claude/.sf/` fixtures, and pipes a JSON payload to
the hook on stdin. The runner globs `tests/integration/*.bats`, so the file needs no
registration.

## This is not a behavior fix

Issue #208 states that the shell parses line 11 as `A || (B && exit 0)`. That is wrong.
`&&` and `||` have equal precedence and bind left to right, so the shell parses it as
`(A || B) && exit 0`. The early exit already worked.

The change removes an ambiguous form that reads as a bug. The hook decision is the same
before and after.

## Test evidence

The BATS file ran against the unmodified hook first. All 8 behavior cases passed. Only
the static guard-shape check failed. This proves the tests drive the real script and
confirms that the fix changes no behavior.

| Check | Result |
| --- | --- |
| `bash -n hooks/validate-implementation.sh` | pass |
| `shellcheck -x hooks/validate-implementation.sh` | pass |
| `tests/run-tests.sh` | 102 of 102 pass |

## Found during work, out of scope

Line 17 is `UNCHECKED=$(echo "$CRITERIA" | grep -c "\[ \]" || echo "0")`. `grep -c`
prints `0` on no match and also returns exit code 1. So `UNCHECKED` becomes two lines and
line 18 prints `[: 0\n0: integer expression expected` to stderr. Stdout stays empty and
the exit code stays 0, so the hook decision is correct. Issue #208 puts this refactor out
of scope. The tests use `run --separate-stderr` and assert on stdout. This needs its own
issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)