### PR TITLE
fix(hooks): count only unchecked criteria

### DIFF
--- a/hooks/validate-implementation.sh
+++ b/hooks/validate-implementation.sh
@@ -13,7 +13,7 @@ if [ ! -f "$SPEC_FILE" ] || [ ! -f "$IMPL_FILE" ]; then exit 0; fi
 CRITERIA=$(grep -i "^\- \[" "$SPEC_FILE" 2>/dev/null)
 [ -z "$CRITERIA" ] && exit 0
 
-UNCHECKED=$(echo "$CRITERIA" | grep -c "\[ \]" || echo "0")
+UNCHECKED=$(echo "$CRITERIA" | grep -c "^\- \[ \]")
 if [ "$UNCHECKED" -gt 0 ]; then
   echo "{\"decision\":\"block\",\"reason\":\"$UNCHECKED acceptance criteria unchecked in spec\"}"
 fi

--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -22,8 +22,7 @@ teardown() {
 }
 
 # Runs the hook with a payload that points at TEST_DIR.
-# Keeps stderr out of $output. Line 17 of the hook prints a shell error
-# when the spec has no unchecked criteria. That refactor is out of scope.
+# Keeps stderr out of $output so that tests can assert on each stream.
 run_hook() {
     local active="${1:-false}"
     run --separate-stderr bash "$HOOK" <<< "{\"cwd\":\"$TEST_DIR\",\"stop_hook_active\":$active}"
@@ -84,6 +83,36 @@ write_impl() {
     run_hook
     [ "$status" -eq 0 ]
     [ -z "$output" ]
+}
+
+@test "checked criterion that quotes an unchecked marker produces no decision" {
+    write_spec '- [x] Spec has one `- [ ]` criterion -> exit 0.'
+    write_impl
+    run_hook
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "counts only the unchecked criteria in a mixed spec" {
+    write_spec \
+        "- [x] first done" \
+        '- [x] second done, and it mentions `- [ ]` in its text' \
+        "- [ ] third not done" \
+        "- [ ] fourth not done"
+    write_impl
+    run_hook
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"2 acceptance criteria unchecked"* ]]
+}
+
+# --- stderr ---
+
+@test "all criteria checked writes nothing to stderr" {
+    write_spec "- [x] done"
+    write_impl
+    run_hook
+    [ "$status" -eq 0 ]
+    [ -z "$stderr" ]
 }
 
 # --- Re-entry guard ---


### PR DESCRIPTION
Closes #228

## What changed

`hooks/validate-implementation.sh` line 16:

```diff
-UNCHECKED=$(echo "$CRITERIA" | grep -c "\[ \]" || echo "0")
+UNCHECKED=$(echo "$CRITERIA" | grep -c "^\- \[ \]")
```

## Two defects, one line

**False positive.** The pattern matched `[ ]` anywhere on the line. A checked criterion
that quoted an unchecked marker in its own text counted as unchecked. The hook then
blocked the stop event. Anchoring to `^- \[ \]` restricts the match to the criterion
prefix.

**Stderr noise.** `grep -c` prints `0` on no match and also returns exit code 1. The
`|| echo "0"` appended a second `0`, so `UNCHECKED` held two lines and line 18 wrote
`[: 0\n0: integer expression expected` to stderr. `grep -c` already supplies the count,
so the fallback is removed. The assignment still returns 1 on no match, but the script
does not use `set -e`, so execution continues.

## Tests

`tests/integration/hooks.bats` gains three cases:

- A checked criterion that quotes `- [ ]` produces no decision.
- A mixed spec counts only the real unchecked criteria.
- An all-checked spec writes nothing to stderr.

All three fail against the unfixed hook and pass against the fixed one:

```
not ok 7 checked criterion that quotes an unchecked marker produces no decision
not ok 8 counts only the unchecked criteria in a mixed spec
not ok 9 all criteria checked writes nothing to stderr
```

The `run_hook` comment that called the stderr noise out of scope is removed.

| Check | Result |
| --- | --- |
| `bash -n hooks/validate-implementation.sh` | pass |
| `shellcheck -x hooks/validate-implementation.sh` | pass |
| `tests/run-tests.sh` | 105 of 105 pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)