### PR TITLE
ci: authenticate release-please with the bitcraft-release App

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,9 +5,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 # Cancel in-progress runs when a new run is triggered
 concurrency:
@@ -20,7 +18,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Run release-please
-        uses: googleapis/release-please-action@v4
+      # Mint a short-lived installation token from the bitcraft-release GitHub App.
+      # The token has no expiry to rotate. Events that the App authors also start
+      # workflows, so CI runs on the release PR. GITHUB_TOKEN cannot do this,
+      # because GitHub suppresses runs for events from a workflow own token.
+      - name: Mint App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      # Third-party actions are SHA-pinned. A tag can move to different code.
+      - name: Run release-please
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Closes #232

> [!IMPORTANT]
> Do not merge until `spec-first` can read the two org secrets. See Prerequisite below.

## Problem

`RELEASE_PLEASE_TOKEN` expired. Every release-please run since 2026-08-02 fails:

```
Running release-please version: 17.3.0
##[error]release-please failed: Bad credentials - https://docs.github.com/rest
```

Five releases were skipped. The last good run was 2026-03-16. Nothing was pushed to
`main` between those dates, so the expiry stayed invisible until the next push.

## Why an App and not a new PAT

| | PAT | `GITHUB_TOKEN` | `bitcraft-release` App |
| --- | --- | --- | --- |
| Expires | yes, this outage | no | no, token is per-run |
| Depends on one person | yes | no | no |
| CI runs on the release PR | yes | **no** | yes |

GitHub suppresses workflow runs for events that come from a workflow own
`GITHUB_TOKEN`. App-authored events are exempt. So the App keeps CI on release PRs and
removes the rotation work.

`pi-web-tools` and `vestimia` already use this pattern.

## Prerequisite, needs org admin

`spec-first` receives no organization secrets today:

```
$ gh api repos/bitcraft-apps/spec-first/actions/organization-secrets
{"total_count":0,"secrets":[]}
```

Add `spec-first` to the repository access list of `RELEASE_BOT_CLIENT_ID` and
`RELEASE_BOT_PRIVATE_KEY`. No new key is needed. The App is installed on the repository
already.

## Changes

- Mint the token with `actions/create-github-app-token`, SHA-pinned to v3.2.0.
- Pass the App token to `release-please-action`, SHA-pinned to v5.0.0.
- Name `config-file` and `manifest-file`, which matches `pi-web-tools`.
- Reduce `permissions` to `contents: read`. The App token carries the write access, so
  `GITHUB_TOKEN` needs none.

Both pins verify against their tags:

```
$ gh api repos/actions/create-github-app-token/git/refs/tags \
    -q '.[] | select(.object.sha=="bcd2ba49218906704ab6c1aa796996da409d3eb1") | .ref'
refs/tags/v3
refs/tags/v3.2.0
```

## After merge

- Confirm a release PR opens for the five unreleased commits.
- Delete the `RELEASE_PLEASE_TOKEN` secret.
- Close #201, the dependabot v4 to v5 bump. This PR pins v5.0.0 directly.

## Out of scope

`concurrency.cancel-in-progress` stays `true`. Cancelling a release run part way is a
real hazard, and `pi-web-tools` sets it to `false`. That is unrelated to the credential
change and needs its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)