### PR TITLE
ci: queue release-please runs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,10 +7,10 @@ on:
 permissions:
   contents: read
 
-# Cancel in-progress runs when a new run is triggered
+# Queue runs. A cancelled run can leave a tag or release without its PR.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: release-please
+  cancel-in-progress: false
 
 jobs:
   release-please:


### PR DESCRIPTION
`cancel-in-progress: true` killed an in-progress release run when a new push to `main`
started one. A release run creates a tag, a GitHub release and a release PR. A cancelled
run can leave part of that work done, and a later run must reconcile it.

The group name is now fixed. The workflow runs only on `main`, so `github.ref` added
nothing. A run takes about 10 seconds, so queueing costs almost nothing.

Closes #235

## Verification

- YAML parses.
- After merge: two commits pushed close together must show the second run as pending,
  and the first run must finish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)