### PR TITLE
fix(agents): give analyze-* agents the Write tool

### DIFF
--- a/agents/analyze-artifacts.md
+++ b/agents/analyze-artifacts.md
@@ -1,7 +1,7 @@
 ---
 name: analyze-artifacts
 description: Read and parse SF artifacts (spec, criteria, risks). Use when documentation needs context from the spec phase.
-tools: Read
+tools: Read, Write
 model: haiku
 maxTurns: 6
 ---

--- a/agents/analyze-existing-docs.md
+++ b/agents/analyze-existing-docs.md
@@ -1,7 +1,7 @@
 ---
 name: analyze-existing-docs
 description: Scan existing docs and produce an inventory manifest. Use when determining which docs to update vs create.
-tools: Read, Glob
+tools: Read, Write, Glob
 model: haiku
 maxTurns: 6
 ---

--- a/agents/analyze-implementation.md
+++ b/agents/analyze-implementation.md
@@ -1,7 +1,7 @@
 ---
 name: analyze-implementation
 description: Analyze code structure and implementation patterns. Use when documentation needs to reflect actual code changes.
-tools: Read, Grep, Glob, LSP
+tools: Read, Write, Grep, Glob, LSP
 model: haiku
 maxTurns: 10
 ---

--- a/tests/integration/plugin-validation.bats
+++ b/tests/integration/plugin-validation.bats
@@ -55,6 +55,22 @@ assert 'version' in data, 'missing version'
     done
 }
 
+@test "agents that declare an output file have Write" {
+    for agent in "$PROJECT_ROOT/agents/"*.md; do
+        # Only agents whose Output line names a .md file. manage-spec-directory
+        # outputs a directory and creates it with Bash.
+        grep -q "^Output:.*\.md" "$agent" || continue
+
+        local frontmatter
+        frontmatter=$(sed -n '/^---$/,/^---$/p' "$agent" | sed '1d;$d')
+
+        echo "$frontmatter" | grep "^tools:" | grep -q "Write" || {
+            echo "$(basename "$agent") declares an output file but has no Write tool" >&2
+            return 1
+        }
+    done
+}
+
 @test "skill frontmatter is parseable YAML" {
     for skill_dir in "$PROJECT_ROOT/skills/"*/; do
         local skill_file="$skill_dir/SKILL.md"


### PR DESCRIPTION
## Problem

`analyze-artifacts`, `analyze-implementation` and `analyze-existing-docs` each declare an
output file, but their `tools:` frontmatter granted no write tool. Gate 1 in
`skills/document/SKILL.md` halts on a missing research file, so every `/sf:document` run
failed and the orchestrator had to write the three files by hand.

## Fix

- `analyze-artifacts` -> `tools: Read, Write`
- `analyze-implementation` -> `tools: Read, Write, Grep, Glob, LSP`
- `analyze-existing-docs` -> `tools: Read, Write, Glob`

New test in `tests/integration/plugin-validation.bats`: an agent whose `Output:` line
names a `.md` file must list `Write`. It fails on the pre-fix frontmatter and names the
agent. `manage-spec-directory` is excluded because its output is a directory that it
creates with Bash.

## Note on the second acceptance criterion

The issue comment reports that `create-technical-docs` and `create-user-docs` write to
`.claude/.sf/docs/` while the skill names `.claude/.sf/research/`. That mismatch is not
in the repo. A search for `sf/docs` across agents, skills, hooks, scripts and tests finds
nothing. All agents and both skills use `.claude/.sf/research/`. No path change was
needed.

## Verification

`make test` — all 106 tests pass. Agent files stay at 20-22 lines, under the 50-line
limit.

Not verified: a live `/sf:document` run. The `sf:*` agents load from the installed plugin
cache, not from this working tree, so a run here would still use version 1.3.1 agent
definitions. This needs a check after release.

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)