### PR TITLE
refactor(tests): use AGENTS.md as the repo marker

### DIFF
--- a/tests/helpers/common.bash
+++ b/tests/helpers/common.bash
@@ -10,10 +10,10 @@ if [ -z "$PROJECT_ROOT" ]; then
         SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
         PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
     else
-        # Fallback: search upward for CLAUDE.md
+        # Fallback: search upward for AGENTS.md
         CURRENT_DIR="$(pwd)"
         while [ "$CURRENT_DIR" != "/" ]; do
-            if [ -f "$CURRENT_DIR/CLAUDE.md" ]; then
+            if [ -f "$CURRENT_DIR/AGENTS.md" ]; then
                 PROJECT_ROOT="$CURRENT_DIR"
                 break
             fi
@@ -49,7 +49,7 @@ test_error() {
 
 # Project validation
 validate_project_root() {
-    if [ -z "$PROJECT_ROOT" ] || [ ! -f "$PROJECT_ROOT/CLAUDE.md" ]; then
+    if [ -z "$PROJECT_ROOT" ] || [ ! -f "$PROJECT_ROOT/AGENTS.md" ]; then
         test_error "Cannot find Spec First project root"
         return 1
     fi

--- a/tests/integration/plugin.bats
+++ b/tests/integration/plugin.bats
@@ -22,7 +22,7 @@ teardown() {
 }
 
 @test "framework directory structure exists" {
-    [ -f "$PROJECT_ROOT/CLAUDE.md" ]
+    [ -f "$PROJECT_ROOT/AGENTS.md" ]
     [ -f "$PROJECT_ROOT/VERSION" ]
     [ -d "$PROJECT_ROOT/skills" ]
     [ -d "$PROJECT_ROOT/agents" ]

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -100,7 +100,7 @@ check_prerequisites() {
     echo "🔍 Checking test prerequisites..."
     
     # Check if we're in the right directory
-    if [ ! -f "$PROJECT_ROOT/CLAUDE.md" ]; then
+    if [ ! -f "$PROJECT_ROOT/AGENTS.md" ]; then
         echo -e "${RED}❌ Not in Spec First repository${NC}" >&2
         exit 1
     fi


### PR DESCRIPTION
## Problem

Test tooling used `CLAUDE.md` to detect the Spec First repository. That file is only a
one-line pointer to `AGENTS.md`. A contributor who deletes the pointer cannot run the tests.

## Fix

Use `AGENTS.md` as the marker:

- `tests/run-tests.sh` — prerequisite check
- `tests/helpers/common.bash` — upward search for `PROJECT_ROOT`, and `validate_project_root()`
- `tests/integration/plugin.bats` — structure assertion

`scripts/validate-plugin.sh` needed no change. It already validates `AGENTS.md` and only warns
when `CLAUDE.md` is absent.

`agents/manage-spec-directory.md` stays as is. It detects the root of a *user* project, which
is the subject of #209.

## Test

- `./tests/run-tests.sh` — 106 tests pass
- `./tests/run-tests.sh` with `CLAUDE.md` removed — 106 tests pass
- `./scripts/validate-plugin.sh` — exit 0

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)