### PR TITLE
feat!: resolve artifact directory to .sf/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ tests/test-results/
 
 # Specification Files
 .sf/
-.claude/.sf/
 
 # Allow committed example output
 !examples/**/output/.sf/

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Researching requirements...
   Batch 1 (parallel): define-scope, create-criteria, identify-risks
   Batch 2: synthesize-spec
 
-Spec written to .claude/.sf/spec.md
+Spec written to .sf/spec.md
 ```
 
 Implement it:
@@ -52,7 +52,7 @@ Step 2: Implementing...
   Updated: src/middleware/index.ts
   Created: src/middleware/rate-limiter.test.ts
 
-Implementation summary written to .claude/.sf/implementation-summary.md
+Implementation summary written to .sf/implementation-summary.md
 ```
 
 Document it:

--- a/agents/analyze-artifacts.md
+++ b/agents/analyze-artifacts.md
@@ -10,8 +10,8 @@ maxTurns: 6
 
 Reads MINIMAL development artifacts for documentation.
 
-Input: Artifact paths from arguments or `.claude/.sf/` directory
-Output: `.claude/.sf/research/artifacts-summary.md`
+Input: Artifact paths from arguments or `.sf/` directory
+Output: `.sf/research/artifacts-summary.md`
 
 Rules:
 - Read only what exists (spec.md, implementation-summary.md)

--- a/agents/analyze-existing-docs.md
+++ b/agents/analyze-existing-docs.md
@@ -10,7 +10,7 @@ maxTurns: 6
 
 Scans project for EXISTING documentation files and produces a manifest.
 
-Output: `.claude/.sf/research/docs-inventory.md`
+Output: `.sf/research/docs-inventory.md`
 
 Rules:
 - Glob `docs/**/*.md`, `*.md` in project root

--- a/agents/analyze-implementation.md
+++ b/agents/analyze-implementation.md
@@ -11,7 +11,7 @@ maxTurns: 10
 Finds ACTUAL implementation structure and patterns.
 
 Input: Implementation paths from arguments or artifact references
-Output: `.claude/.sf/research/implementation-summary.md`
+Output: `.sf/research/implementation-summary.md`
 
 Rules:
 - Find main implementation files and structure

--- a/agents/create-criteria.md
+++ b/agents/create-criteria.md
@@ -11,7 +11,7 @@ maxTurns: 6
 Creates MINIMAL success conditions following KISS principle.
 
 Input: Requirements from arguments
-Output: `.claude/.sf/research/criteria.md`
+Output: `.sf/research/criteria.md`
 
 Rules:
 - Simplest testable conditions only

--- a/agents/create-technical-docs.md
+++ b/agents/create-technical-docs.md
@@ -10,12 +10,12 @@ maxTurns: 15
 Creates MINIMAL developer documentation. Document only what a developer needs to use or extend the change.
 
 Inputs:
-- `.claude/.sf/research/artifacts-summary.md`
-- `.claude/.sf/research/implementation-summary.md`
-- `.claude/.sf/research/docs-inventory.md` (existing doc manifest)
+- `.sf/research/artifacts-summary.md`
+- `.sf/research/implementation-summary.md`
+- `.sf/research/docs-inventory.md` (existing doc manifest)
 
-Output: `.claude/.sf/research/technical-docs.md`
-Shared context: `.claude/.sf/research/doc-context.md`
+Output: `.sf/research/technical-docs.md`
+Shared context: `.sf/research/doc-context.md`
 
 Sections — include ONLY if the change warrants it:
 - ## Overview — only for new features or architectural changes. Skip for config/parameter changes.
@@ -33,5 +33,5 @@ Rules:
 - If unclear whether something needs docs, it doesn't
 
 Shared context convention:
-- If `.claude/.sf/research/doc-context.md` exists, read it for terminology decisions
+- If `.sf/research/doc-context.md` exists, read it for terminology decisions
 - After writing output, append terms and topics to doc-context.md under `## Technical Docs`

--- a/agents/create-user-docs.md
+++ b/agents/create-user-docs.md
@@ -10,12 +10,12 @@ maxTurns: 15
 Creates MINIMAL user-facing docs. Only document what the user needs to DO differently.
 
 Inputs:
-- `.claude/.sf/research/artifacts-summary.md`
-- `.claude/.sf/research/implementation-summary.md`
-- `.claude/.sf/research/docs-inventory.md` (existing doc manifest)
+- `.sf/research/artifacts-summary.md`
+- `.sf/research/implementation-summary.md`
+- `.sf/research/docs-inventory.md` (existing doc manifest)
 
-Output: `.claude/.sf/research/user-docs.md`
-Shared context: `.claude/.sf/research/doc-context.md`
+Output: `.sf/research/user-docs.md`
+Shared context: `.sf/research/doc-context.md`
 
 Sections — include ONLY if the user needs to act:
 - ## What Changed — one paragraph max. Skip if change is invisible to users.
@@ -32,5 +32,5 @@ Rules:
 - If unclear whether something needs user docs, it doesn't
 
 Shared context convention:
-- If `.claude/.sf/research/doc-context.md` exists, read it for terminology decisions
+- If `.sf/research/doc-context.md` exists, read it for terminology decisions
 - After writing output, append terms and topics to doc-context.md under `## User Docs`

--- a/agents/define-scope.md
+++ b/agents/define-scope.md
@@ -11,7 +11,7 @@ maxTurns: 6
 Defines the NARROWEST viable solution following YAGNI principle.
 
 Input: Requirements from arguments
-Output: `.claude/.sf/research/scope.md`
+Output: `.sf/research/scope.md`
 
 Rules:
 - MVP only - exclude everything not immediately needed

--- a/agents/identify-risks.md
+++ b/agents/identify-risks.md
@@ -11,7 +11,7 @@ maxTurns: 6
 Identifies ESSENTIAL risks and blocks following MVP principle.
 
 Input: Requirements from arguments
-Output: `.claude/.sf/research/risks.md`
+Output: `.sf/research/risks.md`
 
 Rules:
 - Focus on blockers, not every possible risk

--- a/agents/implement-minimal.md
+++ b/agents/implement-minimal.md
@@ -10,10 +10,10 @@ maxTurns: 25
 Creates SIMPLEST solution that works.
 
 Inputs:
-- `.claude/.sf/spec.md` or specified path
-- `.claude/.sf/research/pattern-example.md`
+- `.sf/spec.md` or specified path
+- `.sf/research/pattern-example.md`
 
-Output: Working code + `.claude/.sf/implementation-summary.md`
+Output: Working code + `.sf/implementation-summary.md`
 
 Rules:
 - Follow the pattern found, no creativity

--- a/agents/integrate-docs.md
+++ b/agents/integrate-docs.md
@@ -10,10 +10,10 @@ maxTurns: 15
 Merges research docs into existing project docs. Prefer updating over creating.
 
 Inputs:
-- `.claude/.sf/research/technical-docs.md`
-- `.claude/.sf/research/user-docs.md`
-- `.claude/.sf/research/docs-inventory.md` (existing doc manifest)
-- `.claude/.sf/research/doc-context.md` (shared terminology, if present)
+- `.sf/research/technical-docs.md`
+- `.sf/research/user-docs.md`
+- `.sf/research/docs-inventory.md` (existing doc manifest)
+- `.sf/research/doc-context.md` (shared terminology, if present)
 
 Rules:
 - Read docs-inventory.md first — match topics against existing files

--- a/agents/manage-spec-directory.md
+++ b/agents/manage-spec-directory.md
@@ -19,8 +19,8 @@ if [ -z "$SF_DIR" ]; then
         [ "$PROJECT_ROOT" = "/" ] && { echo "Error: project root not found. Looked for .git, AGENTS.md or CLAUDE.md in $(pwd) and every parent directory." >&2; exit 1; }
         PROJECT_ROOT="$(dirname "$PROJECT_ROOT")"
     done
-    SF_DIR="$PROJECT_ROOT/.claude/.sf"
-    [ -d "$PROJECT_ROOT/.git" ] && [ -f "$PROJECT_ROOT/.gitignore" ] && ! grep -qF '.claude/.sf/' "$PROJECT_ROOT/.gitignore" && echo '.claude/.sf/' >> "$PROJECT_ROOT/.gitignore"
+    SF_DIR="$PROJECT_ROOT/.sf"
+    [ -d "$PROJECT_ROOT/.git" ] && [ -f "$PROJECT_ROOT/.gitignore" ] && ! grep -qF '.sf/' "$PROJECT_ROOT/.gitignore" && echo '.sf/' >> "$PROJECT_ROOT/.gitignore"
 fi
 mkdir -p "$SF_DIR" 2>/dev/null || { echo "Error: Cannot create or write to $SF_DIR" >&2; exit 1; }
 if [ -f "$SF_DIR/mode" ]; then

--- a/agents/synthesize-spec.md
+++ b/agents/synthesize-spec.md
@@ -9,8 +9,8 @@ maxTurns: 12
 
 Combines research into MINIMAL actionable specification.
 
-Inputs: `.claude/.sf/research/*.md` (active research directory)
-Output: `.claude/.sf/spec.md` (active spec file)
+Inputs: `.sf/research/*.md` (active research directory)
+Output: `.sf/spec.md` (active spec file)
 
 Rules:
 - Keep specification under 50 lines if possible

--- a/docs/technical-reference.md
+++ b/docs/technical-reference.md
@@ -6,7 +6,7 @@
 - 7 research agents use the Haiku model.
 - 5 synthesis and implementation agents use the model of the caller.
 - 1 built-in Explore subagent finds patterns.
-- All agents write their output to `.claude/.sf/research/`. Git ignores this directory.
+- All agents write their output to `.sf/research/`. Git ignores this directory.
 
 ## Commands
 
@@ -24,7 +24,7 @@ Agent files live in `agents/`. Each file has YAML frontmatter: `name`, `descript
 
 ### pattern-example.md
 
-In `/sf:implement`, Explore (Step 1) writes `.claude/.sf/research/pattern-example.md`. Then `implement-minimal` (Step 2) reads it. The file uses free-form markdown. `skills/implement/SKILL.md` and `agents/implement-minimal.md` refer to it.
+In `/sf:implement`, Explore (Step 1) writes `.sf/research/pattern-example.md`. Then `implement-minimal` (Step 2) reads it. The file uses free-form markdown. `skills/implement/SKILL.md` and `agents/implement-minimal.md` refer to it.
 
 ### plugin.json
 
@@ -100,14 +100,18 @@ The `Stop` event runs two hooks: validate-spec and validate-implementation.
 - Haiku model access for research agents
 - LSP is optional. If LSP is not available, `analyze-implementation` uses Grep and Glob.
 
+### Artifact directory
+
+The artifact directory is `$SF_DIR` if you set that variable. If you do not set it, the
+directory is `.sf/` in the project root.
+
 ### .gitignore
 
 ```gitignore
 .sf/
-.claude/.sf/
 ```
 
-The two entries keep SF artifacts out of the repository.
+This entry keeps SF artifacts out of the repository.
 
 ### Validation
 

--- a/examples/rate-limiter/output/.sf/research/docs-inventory.md
+++ b/examples/rate-limiter/output/.sf/research/docs-inventory.md
@@ -14,7 +14,7 @@
 
 - AGENTS.md — development philosophy
 - CLAUDE.md — references AGENTS.md
-- .claude/.sf/ — auto-generated spec artifacts
+- .sf/ — auto-generated spec artifacts
 
 ## Recommendation
 

--- a/hooks/validate-implementation.sh
+++ b/hooks/validate-implementation.sh
@@ -5,8 +5,9 @@ INPUT=$(cat)
 [ "$(echo "$INPUT" | jq -r '.stop_hook_active // false')" = "true" ] && exit 0
 
 PROJECT_DIR=$(echo "$INPUT" | jq -r '.cwd // ""')
-SPEC_FILE="$PROJECT_DIR/.claude/.sf/spec.md"
-IMPL_FILE="$PROJECT_DIR/.claude/.sf/implementation-summary.md"
+SF_DIR="${SF_DIR:-$PROJECT_DIR/.sf}"
+SPEC_FILE="$SF_DIR/spec.md"
+IMPL_FILE="$SF_DIR/implementation-summary.md"
 
 if [ ! -f "$SPEC_FILE" ] || [ ! -f "$IMPL_FILE" ]; then exit 0; fi
 

--- a/hooks/validate-spec.sh
+++ b/hooks/validate-spec.sh
@@ -5,7 +5,8 @@ INPUT=$(cat)
 [ "$(echo "$INPUT" | jq -r '.stop_hook_active // false')" = "true" ] && exit 0
 
 PROJECT_DIR=$(echo "$INPUT" | jq -r '.cwd // ""')
-SPEC_FILE="$PROJECT_DIR/.claude/.sf/spec.md"
+SF_DIR="${SF_DIR:-$PROJECT_DIR/.sf}"
+SPEC_FILE="$SF_DIR/spec.md"
 
 [ ! -f "$SPEC_FILE" ] && exit 0
 

--- a/skills/document/SKILL.md
+++ b/skills/document/SKILL.md
@@ -17,14 +17,14 @@ Creates minimal, proportional documentation. Match doc weight to change weight.
 ---
 
 ## Project Context
-- Implementation summary: !`test -f .claude/.sf/implementation-summary.md && head -20 .claude/.sf/implementation-summary.md || echo "none"`
+- Implementation summary: !`test -f .sf/implementation-summary.md && head -20 .sf/implementation-summary.md || echo "none"`
 
 ## Input Resolution
 
 **Input Resolution:**
 
 1. If $ARGUMENTS provided: Use as artifact/implementation paths
-2. Else if `.claude/.sf/spec.md` and `.claude/.sf/implementation-summary.md` exist: Use them
+2. Else if `.sf/spec.md` and `.sf/implementation-summary.md` exist: Use them
 3. Else: Use **AskUserQuestion** tool to ask for artifact locations
 
 ## Execution

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -18,7 +18,7 @@ Creates minimal implementation following existing patterns.
 
 ## Project Context
 - Branch: !`git branch --show-current 2>/dev/null`
-- Spec exists: !`test -f .claude/.sf/spec.md && echo "yes" || echo "no"`
+- Spec exists: !`test -f .sf/spec.md && echo "yes" || echo "no"`
 
 ## Input Resolution
 
@@ -26,7 +26,7 @@ Creates minimal implementation following existing patterns.
 
 1. Parse $ARGUMENTS: If `--isolate` is present, set ISOLATE=true and strip it from remaining args
 2. If remaining args provided: Use as specification path or inline requirements
-3. Else if `.claude/.sf/spec.md` exists: Use it
+3. Else if `.sf/spec.md` exists: Use it
 4. Else: Use **AskUserQuestion** tool to ask for specification location
 
 ## Execution
@@ -35,13 +35,13 @@ After input resolution, run sequential agents:
 
 **Step 1: Learn**
 - Use Agent tool with subagent_type="Explore" to find similar patterns in the codebase for: $SPECIFICATION (request "medium" thoroughness in the prompt)
-- Save findings to `.claude/.sf/research/pattern-example.md`
+- Save findings to `.sf/research/pattern-example.md`
 
 **Step 2: Implement**
 - If ISOLATE is true: Task: implement-minimal with spec: $SPECIFICATION, isolation: "worktree"
 - Else: Task: implement-minimal with spec: $SPECIFICATION
 
-Output: Implementation + `.claude/.sf/implementation-summary.md`
+Output: Implementation + `.sf/implementation-summary.md`
 
 ## Philosophy
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -34,18 +34,18 @@ If requirements are vague (< 15 words or unclear), use the **AskUserQuestion** t
 
 ## Directory Management
 
-Claude Code will use `.claude/.sf/` as the working directory.
+Claude Code will use `.sf/` as the working directory.
 
 **Command-level logic:**
 
 ```
-If .claude/.sf/spec.md exists:
+If .sf/spec.md exists:
     Use AskUserQuestion tool: "Existing spec found. What would you like to do?"
       Options: "Update existing" / "Create new"
-    If user chooses update: Write "update" to .claude/.sf/mode
-    If user chooses new: Write "new" to .claude/.sf/mode
+    If user chooses update: Write "update" to .sf/mode
+    If user chooses new: Write "new" to .sf/mode
 Else:
-    Write "first" to .claude/.sf/mode
+    Write "first" to .sf/mode
 ```
 
 ## Execution

--- a/tests/README.md
+++ b/tests/README.md
@@ -338,7 +338,7 @@ teardown() {
 
 Hooks read a JSON payload on stdin and write a decision to stdout. To test a hook:
 
-1. **Make a Temporary Directory**: Create `.claude/.sf/` in it during `setup()`
+1. **Make a Temporary Directory**: Create `.sf/` in it during `setup()`
 2. **Write Fixtures**: Add the files the hook reads, for example `spec.md` and `implementation-summary.md`
 3. **Send the Payload**: Point the `cwd` field at the temporary directory
 4. **Separate stderr**: Use `run --separate-stderr` to keep stderr out of `$output`

--- a/tests/integration/directory-isolation.bats
+++ b/tests/integration/directory-isolation.bats
@@ -61,7 +61,7 @@ run_spec_dir() {
 
     run run_spec_dir "$TEST_DIR/repo/sub"
     [ "$status" -eq 0 ]
-    [ -d "$TEST_DIR/repo/.claude/.sf/research" ]
+    [ -d "$TEST_DIR/repo/.sf/research" ]
 }
 
 @test "manage-spec-directory names the markers when no root exists" {
@@ -117,11 +117,11 @@ run_spec_dir() {
     # Check it guards on .git existence
     grep -q '\.git"' "$agent_file"
 
-    # Check it appends exact pattern .claude/.sf/
-    grep -qF '.claude/.sf/' "$agent_file"
+    # Check it appends exact pattern .sf/
+    grep -qF '.sf/' "$agent_file"
 
     # Check it skips if already present (negated grep guard)
-    grep -q '! grep -qF .*.claude/.sf/' "$agent_file"
+    grep -q '! grep -qF .*.sf/' "$agent_file"
 }
 
 @test "framework validation recognizes manage-spec-directory agent" {

--- a/tests/integration/dynamic-context.bats
+++ b/tests/integration/dynamic-context.bats
@@ -67,40 +67,40 @@ teardown() {
 # --- File existence fallbacks (implement skill) ---
 
 @test "spec exists check returns yes when file present" {
-    mkdir -p "$TEST_DIR/.claude/.sf"
-    touch "$TEST_DIR/.claude/.sf/spec.md"
+    mkdir -p "$TEST_DIR/.sf"
+    touch "$TEST_DIR/.sf/spec.md"
     cd "$TEST_DIR"
-    run bash -c 'test -f .claude/.sf/spec.md && echo "yes" || echo "no"'
+    run bash -c 'test -f .sf/spec.md && echo "yes" || echo "no"'
     [ "$output" = "yes" ]
 }
 
 @test "spec exists check returns no when file missing" {
     cd "$TEST_DIR"
-    run bash -c 'test -f .claude/.sf/spec.md && echo "yes" || echo "no"'
+    run bash -c 'test -f .sf/spec.md && echo "yes" || echo "no"'
     [ "$output" = "no" ]
 }
 
 # --- File existence fallbacks (document skill) ---
 
 @test "implementation summary shows content when file exists" {
-    mkdir -p "$TEST_DIR/.claude/.sf"
-    echo "summary line 1" > "$TEST_DIR/.claude/.sf/implementation-summary.md"
+    mkdir -p "$TEST_DIR/.sf"
+    echo "summary line 1" > "$TEST_DIR/.sf/implementation-summary.md"
     cd "$TEST_DIR"
-    run bash -c 'test -f .claude/.sf/implementation-summary.md && head -20 .claude/.sf/implementation-summary.md || echo "none"'
+    run bash -c 'test -f .sf/implementation-summary.md && head -20 .sf/implementation-summary.md || echo "none"'
     [ "$output" = "summary line 1" ]
 }
 
 @test "implementation summary returns none when file missing" {
     cd "$TEST_DIR"
-    run bash -c 'test -f .claude/.sf/implementation-summary.md && head -20 .claude/.sf/implementation-summary.md || echo "none"'
+    run bash -c 'test -f .sf/implementation-summary.md && head -20 .sf/implementation-summary.md || echo "none"'
     [ "$output" = "none" ]
 }
 
 @test "implementation summary caps at 20 lines" {
-    mkdir -p "$TEST_DIR/.claude/.sf"
-    for i in $(seq 1 30); do echo "line $i"; done > "$TEST_DIR/.claude/.sf/implementation-summary.md"
+    mkdir -p "$TEST_DIR/.sf"
+    for i in $(seq 1 30); do echo "line $i"; done > "$TEST_DIR/.sf/implementation-summary.md"
     cd "$TEST_DIR"
-    run bash -c 'test -f .claude/.sf/implementation-summary.md && head -20 .claude/.sf/implementation-summary.md || echo "none"'
+    run bash -c 'test -f .sf/implementation-summary.md && head -20 .sf/implementation-summary.md || echo "none"'
     [ "${#lines[@]}" -eq 20 ]
 }
 
@@ -116,10 +116,10 @@ teardown() {
 @test "implement skill has Project Context with dynamic injection" {
     grep -q '## Project Context' "$PROJECT_ROOT/skills/implement/SKILL.md"
     grep -q '!`git branch --show-current 2>/dev/null`' "$PROJECT_ROOT/skills/implement/SKILL.md"
-    grep -q '!`test -f .claude/.sf/spec.md && echo "yes" || echo "no"`' "$PROJECT_ROOT/skills/implement/SKILL.md"
+    grep -q '!`test -f .sf/spec.md && echo "yes" || echo "no"`' "$PROJECT_ROOT/skills/implement/SKILL.md"
 }
 
 @test "document skill has Project Context with dynamic injection" {
     grep -q '## Project Context' "$PROJECT_ROOT/skills/document/SKILL.md"
-    grep -q '!`test -f .claude/.sf/implementation-summary.md' "$PROJECT_ROOT/skills/document/SKILL.md"
+    grep -q '!`test -f .sf/implementation-summary.md' "$PROJECT_ROOT/skills/document/SKILL.md"
 }

--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -14,7 +14,7 @@ export HOOK
 setup() {
     TEST_DIR="$(mktemp -d)"
     export TEST_DIR
-    mkdir -p "$TEST_DIR/.claude/.sf"
+    mkdir -p "$TEST_DIR/.sf"
 }
 
 teardown() {
@@ -29,11 +29,11 @@ run_hook() {
 }
 
 write_spec() {
-    printf '%s\n' "$@" > "$TEST_DIR/.claude/.sf/spec.md"
+    printf '%s\n' "$@" > "$TEST_DIR/.sf/spec.md"
 }
 
 write_impl() {
-    echo "summary" > "$TEST_DIR/.claude/.sf/implementation-summary.md"
+    echo "summary" > "$TEST_DIR/.sf/implementation-summary.md"
 }
 
 # --- Guard: missing files exit early ---

--- a/tests/integration/plugin.bats
+++ b/tests/integration/plugin.bats
@@ -73,11 +73,11 @@ teardown() {
 @test "agents have file persistence instructions" {
     # Verify agents write to research directory using literal paths
     grep -q "Output:" "$PROJECT_ROOT/agents/define-scope.md"
-    grep -q "\.claude/\.sf/research.*scope.md" "$PROJECT_ROOT/agents/define-scope.md"
+    grep -q "\.sf/research.*scope.md" "$PROJECT_ROOT/agents/define-scope.md"
 
     # Verify synthesize-spec reads from research
     grep -q "Inputs:" "$PROJECT_ROOT/agents/synthesize-spec.md"
-    grep -q "\.claude/\.sf/research.*\.md" "$PROJECT_ROOT/agents/synthesize-spec.md"
+    grep -q "\.sf/research.*\.md" "$PROJECT_ROOT/agents/synthesize-spec.md"
 
     # Verify agents are focused (small instruction sets)
     line_count=$(wc -l < "$PROJECT_ROOT/agents/define-scope.md")
@@ -85,27 +85,37 @@ teardown() {
 }
 
 @test "agents specify correct file output locations" {
-    # Verify all agents use literal .claude/.sf/research/ paths (not function calls)
+    # Verify all agents use literal .sf/research/ paths (not function calls)
 
-    # Test core research agents output to .claude/.sf/research/
-    grep -q "Output: \`\.claude/\.sf/research/scope\.md\`" "$PROJECT_ROOT/agents/define-scope.md"
-    grep -q "Output: \`\.claude/\.sf/research/criteria\.md\`" "$PROJECT_ROOT/agents/create-criteria.md"
-    grep -q "Output: \`\.claude/\.sf/research/risks\.md\`" "$PROJECT_ROOT/agents/identify-risks.md"
+    # Test core research agents output to .sf/research/
+    grep -q "Output: \`\.sf/research/scope\.md\`" "$PROJECT_ROOT/agents/define-scope.md"
+    grep -q "Output: \`\.sf/research/criteria\.md\`" "$PROJECT_ROOT/agents/create-criteria.md"
+    grep -q "Output: \`\.sf/research/risks\.md\`" "$PROJECT_ROOT/agents/identify-risks.md"
 
-    # Test analysis agents output to .claude/.sf/research/
-    grep -q "Output: \`\.claude/\.sf/research/implementation-summary\.md\`" "$PROJECT_ROOT/agents/analyze-implementation.md"
-    grep -q "Output: \`\.claude/\.sf/research/artifacts-summary\.md\`" "$PROJECT_ROOT/agents/analyze-artifacts.md"
+    # Test analysis agents output to .sf/research/
+    grep -q "Output: \`\.sf/research/implementation-summary\.md\`" "$PROJECT_ROOT/agents/analyze-implementation.md"
+    grep -q "Output: \`\.sf/research/artifacts-summary\.md\`" "$PROJECT_ROOT/agents/analyze-artifacts.md"
 
-    # Test documentation agents output to .claude/.sf/research/
-    grep -q "Output: \`\.claude/\.sf/research/technical-docs\.md\`" "$PROJECT_ROOT/agents/create-technical-docs.md"
-    grep -q "Output: \`\.claude/\.sf/research/user-docs\.md\`" "$PROJECT_ROOT/agents/create-user-docs.md"
+    # Test documentation agents output to .sf/research/
+    grep -q "Output: \`\.sf/research/technical-docs\.md\`" "$PROJECT_ROOT/agents/create-technical-docs.md"
+    grep -q "Output: \`\.sf/research/user-docs\.md\`" "$PROJECT_ROOT/agents/create-user-docs.md"
 
-    # Test synthesis agents use .claude/.sf/ directly
-    grep -q "Output: \`\.claude/\.sf/spec\.md\`" "$PROJECT_ROOT/agents/synthesize-spec.md"
-    grep -q "Output: Working code + \`\.claude/\.sf/implementation-summary\.md\`" "$PROJECT_ROOT/agents/implement-minimal.md"
+    # Test synthesis agents use .sf/ directly
+    grep -q "Output: \`\.sf/spec\.md\`" "$PROJECT_ROOT/agents/synthesize-spec.md"
+    grep -q "Output: Working code + \`\.sf/implementation-summary\.md\`" "$PROJECT_ROOT/agents/implement-minimal.md"
 
     # Verify NO agents use function calls like $(get_research_dir)
     ! grep -r "\$(get_research_dir)" "$PROJECT_ROOT/agents/"
     ! grep -r "\$(get_csf_dir)" "$PROJECT_ROOT/agents/"
+}
+
+@test "no tracked file outside CHANGELOG.md uses the old artifact path" {
+    # Two string parts, so that this test file does not match its own needle
+    local needle=".claude/"".sf"
+
+    cd "$PROJECT_ROOT"
+    # bats-core is a submodule, so git ls-files reports it as a directory
+    run bash -c "git ls-files -z ':!:CHANGELOG.md' ':!:tests/bats-core' | xargs -0 grep -lF -- '$needle'"
+    [ -z "$output" ]
 }
 

--- a/tests/integration/workflow.bats
+++ b/tests/integration/workflow.bats
@@ -137,8 +137,8 @@ teardown() {
 
 @test "synthesize-spec reads from research outputs" {
     # Verify synthesize-spec agent reads from agent outputs using literal paths
-    grep -q "\.claude/\.sf/research" "$PROJECT_ROOT/agents/synthesize-spec.md"
-    grep -q "Inputs.*\.claude/\.sf/research.*\.md" "$PROJECT_ROOT/agents/synthesize-spec.md"
+    grep -q "\.sf/research" "$PROJECT_ROOT/agents/synthesize-spec.md"
+    grep -q "Inputs.*\.sf/research.*\.md" "$PROJECT_ROOT/agents/synthesize-spec.md"
 }
 
 @test "implementation follows sequential workflow" {


### PR DESCRIPTION
## Problem

The artifact directory was the literal string `.claude/.sf/` in about 45 places. `.claude/`
belongs to Claude Code. On pi, opencode or Copilot that directory has no meaning, so sf wrote
its artifacts to a path the host ignores, or made a `.claude/` tree in a project that does not
use Claude Code.

## Change

The directory now resolves to `$SF_DIR` first, then `.sf/` in the project root.

- `agents/manage-spec-directory.md` keeps the only copy of the marker walk. It now builds
  `<project-root>/.sf` and appends `.sf/` to `.gitignore`.
- Both hooks use `SF_DIR="${SF_DIR:-$PROJECT_DIR/.sf}"`.
- Agents and skills name the path in prose, so they carry the literal `.sf/`.
- `.gitignore` drops the `.claude/.sf/` line. The `.sf/` line above it already covers the new
  path.
- `docs/technical-reference.md` gains one section that documents the `SF_DIR` override.

No migration code (YAGNI).

## Breaking change

Existing users must move their artifact directory:

```bash
mv .claude/.sf .sf
```

## Acceptance criteria

- [x] No file outside `CHANGELOG.md` contains `.claude/.sf`. A new test in
      `tests/integration/plugin.bats` guards this.
- [x] `$SF_DIR` overrides the default when set. Covered by the existing test in
      `tests/integration/directory-isolation.bats`.
- [x] `make test` passes — 109 tests, 0 failures.

## Verification

`bash scripts/validate-plugin.sh` passes (100 checks). Manual end-to-end run of the
`manage-spec-directory` bash block from a subdirectory produced `<root>/.sf/research` and
appended `.sf/` to `.gitignore`. `SF_DIR` override produced the custom directory. Both hooks
blocked on the default path and stayed silent when `SF_DIR` pointed at an empty directory.

Part of #219.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)