### PR TITLE
refactor(skills): state a sequential path before the subagent path

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Updated: docs/middleware.md (added rate limiter section)
 
 ## How it works
 
-Each command starts specialized agents. The agents run in parallel when possible. The spec controls the implement step. Claude Code does not write code without a spec.
+Each command starts specialized agents. The agents run in parallel when possible. On a host without subagents, one agent does the same steps in order. The spec controls the implement step. Claude Code does not write code without a spec.
 
 ## Token Usage
 

--- a/docs/technical-reference.md
+++ b/docs/technical-reference.md
@@ -10,7 +10,9 @@
 
 ## Commands
 
-The `skills/` directory defines the commands. Each `SKILL.md` defines the agent orchestration, the batching, and the gates.
+The `skills/` directory defines the commands. Each `SKILL.md` gives the steps and the gates twice: first as one sequential path that any host can run, then as the subagent path under `## On Claude Code`. The subagent path is an optimization.
+
+The steps below are the Claude Code path.
 
 - `/sf:spec [REQUIREMENTS]` runs the research agents in parallel. Then it synthesizes `spec.md`.
 - `/sf:implement [SPEC_OR_PATH]` runs the Explore subagent to find patterns. Then it runs `implement-minimal` to write the code.
@@ -96,7 +98,7 @@ The `Stop` event runs two hooks: validate-spec and validate-implementation.
 
 ## Setup
 
-- Claude Code CLI with `Agent` tool support (`subagent_type`)
+- Claude Code CLI. `Agent` tool support (`subagent_type`) makes the commands run the steps in parallel. Without it, the skills run the same steps in order.
 - Haiku model access for research agents
 - LSP is optional. If LSP is not available, `analyze-implementation` uses Grep and Glob.
 

--- a/skills/document/SKILL.md
+++ b/skills/document/SKILL.md
@@ -8,51 +8,62 @@ allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/scripts/doc-gates.sh:*)
 
 # Document Command
 
-Creates minimal, proportional documentation. Match doc weight to change weight.
+Creates minimal, proportional documentation. Match doc weight to change weight. One agent does
+the steps in order.
 
 ## Usage
 ```
 /sf:document [SPECIFICATION_AND_IMPLEMENTATION_PATHS]
 ```
 
----
+## Context
 
-## Project Context
-- Implementation summary: !`test -f .sf/implementation-summary.md && head -20 .sf/implementation-summary.md || echo "none"`
+Read `.sf/implementation-summary.md` if it exists.
 
 ## Input Resolution
 
-**Input Resolution:**
-
-1. If $ARGUMENTS provided: Use as artifact/implementation paths
-2. Else if `.sf/spec.md` and `.sf/implementation-summary.md` exist: Use them
-3. Else: Use **AskUserQuestion** tool to ask for artifact locations
+1. If the skill has arguments: use them as artifact and implementation paths
+2. Else if `.sf/spec.md` and `.sf/implementation-summary.md` exist: use them
+3. Else: ask the user where the artifacts are. Wait for the answer.
 
 ## Execution
 
-After input resolution, run agents in 3 batches:
+Write each file in turn. All paths are under `$SF_DIR/research/`.
 
-**Batch 1 (Parallel):**
-- Task: analyze-artifacts with requirements: $ARTIFACT_PATHS
-- Task: analyze-implementation with requirements: $IMPLEMENTATION_PATHS
-- Task: analyze-existing-docs (scans project for existing documentation inventory)
+1. `artifacts-summary.md` — the requirements and outcomes in the artifacts. Read only what exists.
+2. `implementation-summary.md` — the real code structure: the main files, the changed interfaces.
+3. `docs-inventory.md` — every existing doc as `filepath | primary topic`, from the headings only.
 
-**Gate 1 — Post-Analysis:**
-- Bash: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/doc-gates.sh analysis ${CLAUDE_PROJECT_DIR:+$CLAUDE_PROJECT_DIR/.sf}`
-- **If doc-gates.sh fails (non-zero exit), halt immediately — do not run Batch 2.**
+**Gate 1 — Post-Analysis:** run `doc-gates.sh analysis`. The script is at `../../scripts/`
+relative to this skill directory.
+**If doc-gates.sh fails (non-zero exit), halt immediately — do not write the documents.**
 
-**Batch 2 (Parallel):**
-- Task: create-technical-docs (reads $SF_DIR/research/artifacts-summary.md, $SF_DIR/research/implementation-summary.md)
-- Task: create-user-docs (reads $SF_DIR/research/artifacts-summary.md, $SF_DIR/research/implementation-summary.md)
+4. `technical-docs.md` — what a developer needs to use or extend the change. Skip any section
+   that does not apply.
+5. `user-docs.md` — only what the user must do differently. Skip it if the change is invisible.
 
-**Gate 2 — Post-Generation:**
-- Bash: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/doc-gates.sh generation ${CLAUDE_PROJECT_DIR:+$CLAUDE_PROJECT_DIR/.sf}`
-- **If doc-gates.sh fails (non-zero exit), halt immediately — do not run Batch 3.**
+An empty file is a valid result. It means the change does not need that document.
 
-**Batch 3:**
-- Task: integrate-docs (reads docs-inventory.md to update existing files or create new ones)
+**Gate 2 — Post-Generation:** run `doc-gates.sh generation`.
+**If doc-gates.sh fails (non-zero exit), halt immediately — do not integrate.**
+
+6. Integrate: for each topic in `docs-inventory.md` that matches, edit that file. Create a file
+   only when none fits. Cut duplicate content. Then delete the research files.
 
 Output: Documentation updates (if any) + terminal summary
 
 ## Gate Failure Behavior
 On a non-zero gate exit: halt, report which gate failed and the reason it printed, and keep the output for inspection.
+
+## On Claude Code
+
+Claude Code has subagents. Use them to run the steps in three batches.
+
+- Implementation summary: !`test -f .sf/implementation-summary.md && head -20 .sf/implementation-summary.md || echo "none"`
+- Use the **AskUserQuestion** tool to ask for the artifact locations.
+- Batch 1 (Parallel): analyze-artifacts, analyze-implementation, analyze-existing-docs
+- Gate 1: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/doc-gates.sh analysis ${CLAUDE_PROJECT_DIR:+$CLAUDE_PROJECT_DIR/.sf}`
+- Batch 2 (Parallel): create-technical-docs, create-user-docs. They share terminology through
+  `$SF_DIR/research/doc-context.md`. One agent working alone does not need that file.
+- Gate 2: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/doc-gates.sh generation ${CLAUDE_PROJECT_DIR:+$CLAUDE_PROJECT_DIR/.sf}`
+- Batch 3: integrate-docs

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -7,41 +7,41 @@ argument-hint: "[--isolate] [SPECIFICATION_OR_PATH]"
 
 # Implement Command
 
-Creates minimal implementation following existing patterns.
+Creates a minimal implementation that follows the existing patterns. One agent does the steps
+in order.
 
 ## Usage
 ```
 /sf:implement [--isolate] [SPECIFICATION_OR_PATH]
 ```
 
----
+## Context
 
-## Project Context
-- Branch: !`git branch --show-current 2>/dev/null`
-- Spec exists: !`test -f .sf/spec.md && echo "yes" || echo "no"`
+Read the current branch. Check whether `.sf/spec.md` exists.
 
 ## Input Resolution
 
-**Input Resolution:**
-
-1. Parse $ARGUMENTS: If `--isolate` is present, set ISOLATE=true and strip it from remaining args
-2. If remaining args provided: Use as specification path or inline requirements
-3. Else if `.sf/spec.md` exists: Use it
-4. Else: Use **AskUserQuestion** tool to ask for specification location
+1. If the skill has arguments: use them as a specification path or as inline requirements
+2. Else if `.sf/spec.md` exists: use it
+3. Else: ask the user where the specification is. Wait for the answer.
 
 ## Execution
 
-After input resolution, run sequential agents:
+**Step 1 — Learn**
+- Search the codebase for the closest existing pattern for this specification. Stop when you
+  have one good example. Do not survey the whole repository.
+- Write the example to `.sf/research/pattern-example.md`.
 
-**Step 1: Learn**
-- Use Agent tool with subagent_type="Explore" to find similar patterns in the codebase for: $SPECIFICATION (request "medium" thoroughness in the prompt)
-- Save findings to `.sf/research/pattern-example.md`
-
-**Step 2: Implement**
-- If ISOLATE is true: Task: implement-minimal with spec: $SPECIFICATION, isolation: "worktree"
-- Else: Task: implement-minimal with spec: $SPECIFICATION
+**Step 2 — Implement**
+- Follow the pattern you found. No creativity.
+- Write the simplest change that works. No abstractions for later. One feature at a time.
+- Test that it works.
+- Write `.sf/implementation-summary.md`.
 
 Output: Implementation + `.sf/implementation-summary.md`
+
+If Step 1 finds no pattern: create the basic file structure the language expects, implement only
+the core requirement, and note in the summary: "No existing patterns found - used minimal approach".
 
 ## Philosophy
 
@@ -50,10 +50,17 @@ This command enforces:
 - Working code over perfect code
 - Minimal solution over extensible solution
 
-## Error Recovery
+## On Claude Code
 
-If exploration finds no patterns:
-1. implement-minimal creates basic file structure following language conventions
-2. Implements only the core requirement (no extras)
-3. Uses standard naming patterns for the technology
-4. Notes in summary: "No existing patterns found - used minimal approach"
+Claude Code has subagents. Use them for both steps.
+
+Context arrives for free:
+- Branch: !`git branch --show-current 2>/dev/null`
+- Spec exists: !`test -f .sf/spec.md && echo "yes" || echo "no"`
+
+- Parse $ARGUMENTS. `--isolate` is a Claude-only flag: strip it and set ISOLATE=true.
+- Use the **AskUserQuestion** tool to ask for the specification location.
+- Step 1: use the Agent tool with subagent_type="Explore" to find the pattern for $SPECIFICATION
+  (request "medium" thoroughness in the prompt).
+- Step 2: Task: implement-minimal with spec: $SPECIFICATION. If ISOLATE is true, add
+  isolation: "worktree".

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -8,24 +8,22 @@ allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/scripts/spec-dir.sh:*)
 
 # Spec Command
 
-Creates specifications with intelligent clarification.
+Creates a specification from requirements. One agent does the steps in order.
 
 ## Usage
 ```
 /sf:spec [REQUIREMENTS]
 ```
 
----
+## Context
 
-## Project Context
-- Branch: !`git branch --show-current 2>/dev/null`
-- Recent commits: !`git log --oneline -5 2>/dev/null`
-- Working tree: !`git status --short 2>/dev/null | head -20`
-- Existing spec: !`test -f .sf/spec.md && echo "yes" || echo "no"`
+Read the current branch, the last 5 commits, and the working tree.
+Check whether `.sf/spec.md` exists.
 
 ## Clarification Check
 
-If requirements are vague (< 15 words or unclear), use the **AskUserQuestion** tool to gather missing context. Do NOT output questions as plain text — always use the tool so execution pauses for the user's answer.
+If the requirements are vague (fewer than 15 words, or unclear), ask the user before you start.
+Wait for the answer. Do not assume.
 
 **Questions to consider asking:**
 - What specific problem are you solving?
@@ -36,43 +34,41 @@ If requirements are vague (< 15 words or unclear), use the **AskUserQuestion** t
 
 ## Directory Management
 
-Claude Code will use `.sf/` as the working directory.
+The working directory is `.sf/`. `$SF_DIR` overrides it.
 
-**Command-level logic:**
+Pick the mode:
+- No `.sf/spec.md` → `first`
+- `.sf/spec.md` exists → ask the user: "Update existing" / "Create new" → `update` / `new`
 
-```
-If Existing spec is "yes":
-    Use AskUserQuestion tool: "Existing spec found. What would you like to do?"
-      Options: "Update existing" / "Create new"
-    "Update existing" → MODE=update
-    "Create new" → MODE=new
-Else:
-    MODE=first
-```
+Run `spec-dir.sh <first|update|new>`, at `../../scripts/` relative to this skill directory.
+The script finds the project root itself.
+**If spec-dir.sh fails (non-zero exit), halt immediately — do not do the work below.**
 
 ## Execution
 
-After directory setup and clarification (if needed), run agents:
+Write each file in turn. The requirements are the input to this skill.
 
-**Pre-execution:**
-- Bash: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/spec-dir.sh $MODE ${CLAUDE_PROJECT_DIR:+$CLAUDE_PROJECT_DIR/.sf}`
-  The script finds the project root itself if `CLAUDE_PROJECT_DIR` is not set.
-- **If spec-dir.sh fails (non-zero exit), halt immediately — do not run downstream agents.**
-
-**Batch 1 (Parallel):**
-- Task: define-scope with requirements: $ARGUMENTS
-- Task: create-criteria with requirements: $ARGUMENTS
-- Task: identify-risks with requirements: $ARGUMENTS
-
-**Batch 2:**
-- Task: synthesize-spec to combine all research, following the structure in `${CLAUDE_SKILL_DIR}/spec-template.md`
+1. `.sf/research/scope.md` — the narrowest viable change. Exclude what is not needed now.
+2. `.sf/research/criteria.md` — the simplest testable pass/fail conditions.
+3. `.sf/research/risks.md` — blockers only, not every possible risk.
+4. `$SF_DIR/spec.md` — merge the three files. Keep it under 50 lines. Use the structure in
+   `spec-template.md`, next to this file.
 
 Output: `$SF_DIR/spec.md` (direct file or symlink to timestamped spec)
 
-## Error Recovery
+Say: "Spec written to `{output path}`. Run `/sf:implement` to build it."
 
-If any agent fails:
-1. Claude Code shows the specific error
-2. Fix the issue (usually unclear requirements)
-3. Re-run /sf:spec with clearer input
-4. No partial state - each run starts fresh
+## On Claude Code
+
+Claude Code has subagents. Use them to run steps 1 to 3 at the same time.
+
+Context arrives for free:
+- Branch: !`git branch --show-current 2>/dev/null`
+- Recent commits: !`git log --oneline -5 2>/dev/null`
+- Working tree: !`git status --short 2>/dev/null | head -20`
+- Existing spec: !`test -f .sf/spec.md && echo "yes" || echo "no"`
+
+- Use the **AskUserQuestion** tool for both questions above, so execution pauses for the answer.
+- Bash: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/spec-dir.sh $MODE ${CLAUDE_PROJECT_DIR:+$CLAUDE_PROJECT_DIR/.sf}`
+- Batch 1 (Parallel): define-scope, create-criteria, identify-risks — each with requirements: $ARGUMENTS
+- Batch 2: synthesize-spec, following `${CLAUDE_SKILL_DIR}/spec-template.md`

--- a/tests/integration/dynamic-context.bats
+++ b/tests/integration/dynamic-context.bats
@@ -104,22 +104,22 @@ teardown() {
     [ "${#lines[@]}" -eq 20 ]
 }
 
-# --- Skills contain Project Context sections ---
+# --- Skills keep the injection under the Claude Code section ---
 
 @test "spec skill has Project Context with dynamic injection" {
-    grep -q '## Project Context' "$PROJECT_ROOT/skills/spec/SKILL.md"
+    grep -q '## On Claude Code' "$PROJECT_ROOT/skills/spec/SKILL.md"
     grep -q '!`git branch --show-current 2>/dev/null`' "$PROJECT_ROOT/skills/spec/SKILL.md"
     grep -q '!`git log --oneline -5 2>/dev/null`' "$PROJECT_ROOT/skills/spec/SKILL.md"
     grep -q '!`git status --short 2>/dev/null | head -20`' "$PROJECT_ROOT/skills/spec/SKILL.md"
 }
 
 @test "implement skill has Project Context with dynamic injection" {
-    grep -q '## Project Context' "$PROJECT_ROOT/skills/implement/SKILL.md"
+    grep -q '## On Claude Code' "$PROJECT_ROOT/skills/implement/SKILL.md"
     grep -q '!`git branch --show-current 2>/dev/null`' "$PROJECT_ROOT/skills/implement/SKILL.md"
     grep -q '!`test -f .sf/spec.md && echo "yes" || echo "no"`' "$PROJECT_ROOT/skills/implement/SKILL.md"
 }
 
 @test "document skill has Project Context with dynamic injection" {
-    grep -q '## Project Context' "$PROJECT_ROOT/skills/document/SKILL.md"
+    grep -q '## On Claude Code' "$PROJECT_ROOT/skills/document/SKILL.md"
     grep -q '!`test -f .sf/implementation-summary.md' "$PROJECT_ROOT/skills/document/SKILL.md"
 }

--- a/tests/integration/workflow.bats
+++ b/tests/integration/workflow.bats
@@ -94,6 +94,24 @@ teardown() {
     grep -q "integrate-docs" "$PROJECT_ROOT/skills/document/SKILL.md"
 }
 
+# The body up to "## On Claude Code" must run on a host without subagents.
+# Skips the frontmatter, which is host-specific by nature.
+default_path() {
+    awk 'NR>1 && /^---$/ {body=1; next} /^## On Claude Code/ {exit} body' \
+        "$PROJECT_ROOT/skills/$1/SKILL.md"
+}
+
+@test "default path of every skill is host-neutral" {
+    local pattern
+    pattern="$(basename -a "$PROJECT_ROOT"/agents/*.md | sed 's/\.md$//' | paste -sd'|' -)"
+
+    for skill in spec implement document; do
+        grep -q '^## On Claude Code' "$PROJECT_ROOT/skills/$skill/SKILL.md"
+        ! default_path "$skill" \
+            | grep -qE 'Task:|subagent_type|AskUserQuestion|\$\{CLAUDE_|Explore'"|$pattern"
+    done
+}
+
 @test "spec skill orchestrates agents" {
     # Check that spec skill references agents
     grep -q "define-scope" "$PROJECT_ROOT/skills/spec/SKILL.md"


### PR DESCRIPTION
Closes #240

## Problem

Each skill body narrated Claude-only mechanics as the only path: `Task: define-scope`,
`subagent_type="Explore"`, `Use **AskUserQuestion** tool`, `${CLAUDE_SKILL_DIR}` and
`${CLAUDE_PLUGIN_ROOT}`. A host with no subagents read instructions it cannot follow.

## Fix

Every body now gives the steps twice, in the same shape:

- The default path is sequential and host-neutral. It names the work, not the agent
  (`.sf/research/scope.md` — narrowest viable change), asks the user in prose, and calls
  `spec-dir.sh` and `doc-gates.sh` by a path relative to the skill directory.
- `## On Claude Code` holds the batches, the subagent names, the tools, the `!` context
  injection and the `${CLAUDE_*}` variables, as an optimization a host may take.

`disable-model-invocation: true` stays. Each file is under the 75-line limit (74/66/69).

`doc-context.md` is now stated for what it is: a convention of the parallel path. One agent
working alone already holds the terminology.

## Tests

The Claude mechanics survive in the new section, so most assertions stayed green untouched.

- New: `default path of every skill is host-neutral` — the body up to `## On Claude Code`
  names no agent, no `Task:`, no `subagent_type`, no `AskUserQuestion` and no `${CLAUDE_`
  variable. This is the acceptance criterion and nothing covered it before.
- `dynamic-context.bats` — the three heading greps expect `## On Claude Code` instead of
  `## Project Context`. The injection lines are unchanged.

128 tests pass. `validate-plugin.sh` exits 0. I also ran the sequential path's script calls
by hand from each skill directory in a scratch repo: `spec-dir.sh first` creates
`.sf/research/`, and both gates pass, including an empty `user-docs.md`.

## Note

`../../scripts/` resolves only for a host that copies the whole plugin tree. Installing the
scripts alongside the skills for pi, opencode and Copilot is #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)