### PR TITLE
feat: validate spec and implementation without hooks

### DIFF
--- a/docs/technical-reference.md
+++ b/docs/technical-reference.md
@@ -94,7 +94,10 @@ Schema:
 
 Hook commands use `${CLAUDE_PLUGIN_ROOT}` as a path prefix. At run time, Claude Code replaces this prefix with the install directory of the plugin. Thus the hook scripts do not contain absolute paths.
 
-The `Stop` event runs two hooks: validate-spec and validate-implementation.
+The `Stop` event runs two hooks: validate-spec and validate-implementation. Each hook is an
+adapter. It reads the hook JSON, calls the matching script in `scripts/`, and reports a non-zero
+exit as a `block` decision. The skills call the same scripts, so hosts without hooks get the
+same checks.
 
 ## Setup
 
@@ -116,6 +119,11 @@ the directory from its second argument, then `$SF_DIR`, then the project root.
 research files. It exits non-zero and prints the reason if a file is missing, or if a generated
 doc contains a placeholder marker. The script reads the directory from its second argument,
 then `$SF_DIR`, then `.sf` in the current directory.
+
+`scripts/validate-spec.sh [sf-dir]` checks that `spec.md` has a scope, criteria and risks
+section. `scripts/validate-implementation.sh [sf-dir]` counts the acceptance criteria that
+`spec.md` still has unchecked. Both exit non-zero and print the reason to stderr. Both read the
+directory from their first argument, then `$SF_DIR`, then `.sf` in the current directory.
 
 ### .gitignore
 

--- a/hooks/validate-implementation.sh
+++ b/hooks/validate-implementation.sh
@@ -1,21 +1,12 @@
 #!/bin/bash
-# SF Implementation validation hook - validates implementation against spec
+# Claude Stop hook adapter - runs scripts/validate-implementation.sh and reports its result
 
 INPUT=$(cat)
 [ "$(echo "$INPUT" | jq -r '.stop_hook_active // false')" = "true" ] && exit 0
 
 PROJECT_DIR=$(echo "$INPUT" | jq -r '.cwd // ""')
-SF_DIR="${SF_DIR:-$PROJECT_DIR/.sf}"
-SPEC_FILE="$SF_DIR/spec.md"
-IMPL_FILE="$SF_DIR/implementation-summary.md"
+SCRIPT="$(dirname "$0")/../scripts/validate-implementation.sh"
 
-if [ ! -f "$SPEC_FILE" ] || [ ! -f "$IMPL_FILE" ]; then exit 0; fi
-
-CRITERIA=$(grep -i "^\- \[" "$SPEC_FILE" 2>/dev/null)
-[ -z "$CRITERIA" ] && exit 0
-
-UNCHECKED=$(echo "$CRITERIA" | grep -c "^\- \[ \]")
-if [ "$UNCHECKED" -gt 0 ]; then
-  echo "{\"decision\":\"block\",\"reason\":\"$UNCHECKED acceptance criteria unchecked in spec\"}"
-fi
+REASON=$(bash "$SCRIPT" "${SF_DIR:-$PROJECT_DIR/.sf}" 2>&1 >/dev/null) \
+  || jq -nc --arg reason "$REASON" '{decision:"block",reason:$reason}'
 exit 0

--- a/hooks/validate-spec.sh
+++ b/hooks/validate-spec.sh
@@ -1,22 +1,12 @@
 #!/bin/bash
-# SF Spec validation hook - validates spec.md structure
+# Claude Stop hook adapter - runs scripts/validate-spec.sh and reports its result
 
 INPUT=$(cat)
 [ "$(echo "$INPUT" | jq -r '.stop_hook_active // false')" = "true" ] && exit 0
 
 PROJECT_DIR=$(echo "$INPUT" | jq -r '.cwd // ""')
-SF_DIR="${SF_DIR:-$PROJECT_DIR/.sf}"
-SPEC_FILE="$SF_DIR/spec.md"
+SCRIPT="$(dirname "$0")/../scripts/validate-spec.sh"
 
-[ ! -f "$SPEC_FILE" ] && exit 0
-
-MISSING=""
-grep -qi "scope\|problem" "$SPEC_FILE" || MISSING="$MISSING scope/problem,"
-grep -qi "criteria\|acceptance" "$SPEC_FILE" || MISSING="$MISSING acceptance criteria,"
-grep -qi "risk" "$SPEC_FILE" || MISSING="$MISSING risks,"
-
-if [ -n "$MISSING" ]; then
-  MISSING="${MISSING%,}"
-  echo "{\"decision\":\"block\",\"reason\":\"Spec missing sections:$MISSING\"}"
-fi
+REASON=$(bash "$SCRIPT" "${SF_DIR:-$PROJECT_DIR/.sf}" 2>&1 >/dev/null) \
+  || jq -nc --arg reason "$REASON" '{decision:"block",reason:$reason}'
 exit 0

--- a/scripts/validate-implementation.sh
+++ b/scripts/validate-implementation.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Implementation check - counts the acceptance criteria the spec still has unchecked
+# Usage: validate-implementation.sh [sf-dir]
+
+SF_DIR="${1:-${SF_DIR:-.sf}}"
+SPEC_FILE="$SF_DIR/spec.md"
+IMPL_FILE="$SF_DIR/implementation-summary.md"
+
+# Before both files exist there is nothing to compare.
+if [ ! -f "$SPEC_FILE" ] || [ ! -f "$IMPL_FILE" ]; then exit 0; fi
+
+CRITERIA=$(grep -i "^\- \[" "$SPEC_FILE" 2>/dev/null)
+[ -z "$CRITERIA" ] && exit 0
+
+UNCHECKED=$(echo "$CRITERIA" | grep -c "^\- \[ \]")
+if [ "$UNCHECKED" -gt 0 ]; then
+    echo "$UNCHECKED acceptance criteria unchecked in spec" >&2
+    exit 1
+fi
+exit 0

--- a/scripts/validate-implementation.test.bats
+++ b/scripts/validate-implementation.test.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+
+# Unit tests for scripts/validate-implementation.sh
+
+bats_require_minimum_version 1.5.0
+
+PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+export PROJECT_ROOT
+VALIDATE_IMPL_SH="$PROJECT_ROOT/scripts/validate-implementation.sh"
+export VALIDATE_IMPL_SH
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    export TEST_DIR
+    mkdir -p "$TEST_DIR/.sf"
+    unset SF_DIR
+}
+
+teardown() {
+    [ -n "$TEST_DIR" ] && rm -rf "$TEST_DIR"
+}
+
+# Run the script from $1 with the remaining arguments, and no stdin
+run_validate_impl() {
+    local cwd="$1"; shift
+    (cd "$cwd" && bash "$VALIDATE_IMPL_SH" "$@" < /dev/null)
+}
+
+write_spec() {
+    printf '%s\n' "$@" > "$TEST_DIR/.sf/spec.md"
+}
+
+write_impl() {
+    echo "summary" > "$TEST_DIR/.sf/implementation-summary.md"
+}
+
+# --- Guard: missing files exit early ---
+
+@test "a missing spec exits 0 with no output" {
+    write_impl
+
+    run --separate-stderr run_validate_impl "$TEST_DIR" "$TEST_DIR/.sf"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    [ -z "$stderr" ]
+}
+
+@test "a missing implementation summary exits 0 with no output" {
+    write_spec "- [ ] unchecked criterion"
+
+    run --separate-stderr run_validate_impl "$TEST_DIR" "$TEST_DIR/.sf"
+    [ "$status" -eq 0 ]
+    [ -z "$stderr" ]
+}
+
+@test "both files missing exits 0 with no output" {
+    run --separate-stderr run_validate_impl "$TEST_DIR" "$TEST_DIR/.sf"
+    [ "$status" -eq 0 ]
+    [ -z "$stderr" ]
+}
+
+# --- The count ---
+
+@test "an unchecked criterion fails" {
+    write_spec "- [ ] unchecked criterion"
+    write_impl
+
+    run --separate-stderr run_validate_impl "$TEST_DIR" "$TEST_DIR/.sf"
+    [ "$status" -eq 1 ]
+    [ "$stderr" = "1 acceptance criteria unchecked in spec" ]
+}
+
+@test "all criteria checked passes" {
+    write_spec "- [x] done" "- [x] also done"
+    write_impl
+
+    run --separate-stderr run_validate_impl "$TEST_DIR" "$TEST_DIR/.sf"
+    [ "$status" -eq 0 ]
+    [ -z "$stderr" ]
+}
+
+@test "a spec with no criteria passes" {
+    write_spec "# Spec" "No criteria here."
+    write_impl
+
+    run --separate-stderr run_validate_impl "$TEST_DIR" "$TEST_DIR/.sf"
+    [ "$status" -eq 0 ]
+    [ -z "$stderr" ]
+}
+
+@test "a checked criterion that quotes an unchecked marker passes" {
+    write_spec '- [x] Spec has one `- [ ]` criterion -> exit 0.'
+    write_impl
+
+    run run_validate_impl "$TEST_DIR" "$TEST_DIR/.sf"
+    [ "$status" -eq 0 ]
+}
+
+@test "it counts only the unchecked criteria in a mixed spec" {
+    write_spec \
+        "- [x] first done" \
+        '- [x] second done, and it mentions `- [ ]` in its text' \
+        "- [ ] third not done" \
+        "- [ ] fourth not done"
+    write_impl
+
+    run --separate-stderr run_validate_impl "$TEST_DIR" "$TEST_DIR/.sf"
+    [ "$status" -eq 1 ]
+    [ "$stderr" = "2 acceptance criteria unchecked in spec" ]
+}
+
+# --- Directory resolution ---
+
+@test "the directory argument wins over SF_DIR" {
+    export SF_DIR="$TEST_DIR/from-env"
+    mkdir -p "$TEST_DIR/from-arg"
+    printf '%s\n' "- [x] done" > "$TEST_DIR/from-arg/spec.md"
+    echo "summary" > "$TEST_DIR/from-arg/implementation-summary.md"
+
+    run run_validate_impl "$TEST_DIR" "$TEST_DIR/from-arg"
+    [ "$status" -eq 0 ]
+}
+
+@test "an empty directory argument falls back to SF_DIR" {
+    export SF_DIR="$TEST_DIR/custom"
+    mkdir -p "$SF_DIR"
+    printf '%s\n' "- [ ] not done" > "$SF_DIR/spec.md"
+    echo "summary" > "$SF_DIR/implementation-summary.md"
+
+    run run_validate_impl "$TEST_DIR" ""
+    [ "$status" -eq 1 ]
+}
+
+@test "without a directory it reads .sf in the current directory" {
+    write_spec "- [ ] not done"
+    write_impl
+
+    run run_validate_impl "$TEST_DIR"
+    [ "$status" -eq 1 ]
+}
+
+@test "script has no syntax error" {
+    run bash -n "$VALIDATE_IMPL_SH"
+    [ "$status" -eq 0 ]
+}

--- a/scripts/validate-spec.sh
+++ b/scripts/validate-spec.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Spec structure check - reports the sections spec.md does not have
+# Usage: validate-spec.sh [sf-dir]
+
+SPEC_FILE="${1:-${SF_DIR:-.sf}}/spec.md"
+
+# No spec yet means nothing to check.
+[ ! -f "$SPEC_FILE" ] && exit 0
+
+MISSING=""
+grep -qi "scope\|problem" "$SPEC_FILE" || MISSING="$MISSING scope/problem,"
+grep -qi "criteria\|acceptance" "$SPEC_FILE" || MISSING="$MISSING acceptance criteria,"
+grep -qi "risk" "$SPEC_FILE" || MISSING="$MISSING risks,"
+
+if [ -n "$MISSING" ]; then
+    echo "Spec missing sections:${MISSING%,}" >&2
+    exit 1
+fi
+exit 0

--- a/scripts/validate-spec.test.bats
+++ b/scripts/validate-spec.test.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+
+# Unit tests for scripts/validate-spec.sh
+
+bats_require_minimum_version 1.5.0
+
+PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+export PROJECT_ROOT
+VALIDATE_SPEC_SH="$PROJECT_ROOT/scripts/validate-spec.sh"
+export VALIDATE_SPEC_SH
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    export TEST_DIR
+    mkdir -p "$TEST_DIR/.sf"
+    unset SF_DIR
+}
+
+teardown() {
+    [ -n "$TEST_DIR" ] && rm -rf "$TEST_DIR"
+}
+
+# Run the script from $1 with the remaining arguments, and no stdin
+run_validate_spec() {
+    local cwd="$1"; shift
+    (cd "$cwd" && bash "$VALIDATE_SPEC_SH" "$@" < /dev/null)
+}
+
+# Write a spec that has every section
+write_complete_spec() {
+    printf '%s\n' "## Scope" "## Acceptance Criteria" "## Risks" > "$1"
+}
+
+@test "a missing spec exits 0 with no output" {
+    run --separate-stderr run_validate_spec "$TEST_DIR" "$TEST_DIR/.sf"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    [ -z "$stderr" ]
+}
+
+@test "a complete spec passes" {
+    write_complete_spec "$TEST_DIR/.sf/spec.md"
+
+    run --separate-stderr run_validate_spec "$TEST_DIR" "$TEST_DIR/.sf"
+    [ "$status" -eq 0 ]
+    [ -z "$stderr" ]
+}
+
+@test "a spec with no sections names all three" {
+    printf '# Spec\nnothing useful here\n' > "$TEST_DIR/.sf/spec.md"
+
+    run --separate-stderr run_validate_spec "$TEST_DIR" "$TEST_DIR/.sf"
+    [ "$status" -eq 1 ]
+    [ "$stderr" = "Spec missing sections: scope/problem, acceptance criteria, risks" ]
+}
+
+@test "the scope section also matches the word problem" {
+    printf '%s\n' "## Problem" "## Acceptance Criteria" "## Risks" > "$TEST_DIR/.sf/spec.md"
+
+    run run_validate_spec "$TEST_DIR" "$TEST_DIR/.sf"
+    [ "$status" -eq 0 ]
+}
+
+@test "it names only the missing section" {
+    printf '%s\n' "## Scope" "## Risks" > "$TEST_DIR/.sf/spec.md"
+
+    run --separate-stderr run_validate_spec "$TEST_DIR" "$TEST_DIR/.sf"
+    [ "$status" -eq 1 ]
+    [ "$stderr" = "Spec missing sections: acceptance criteria" ]
+}
+
+@test "section names match in any case" {
+    printf '%s\n' "## SCOPE" "## acceptance" "## RiSk" > "$TEST_DIR/.sf/spec.md"
+
+    run run_validate_spec "$TEST_DIR" "$TEST_DIR/.sf"
+    [ "$status" -eq 0 ]
+}
+
+@test "the directory argument wins over SF_DIR" {
+    export SF_DIR="$TEST_DIR/from-env"
+    mkdir -p "$TEST_DIR/from-arg"
+    write_complete_spec "$TEST_DIR/from-arg/spec.md"
+
+    run run_validate_spec "$TEST_DIR" "$TEST_DIR/from-arg"
+    [ "$status" -eq 0 ]
+}
+
+@test "an empty directory argument falls back to SF_DIR" {
+    export SF_DIR="$TEST_DIR/custom"
+    mkdir -p "$SF_DIR"
+    printf '# Spec\nnothing useful here\n' > "$SF_DIR/spec.md"
+
+    run run_validate_spec "$TEST_DIR" ""
+    [ "$status" -eq 1 ]
+}
+
+@test "without a directory it reads .sf in the current directory" {
+    printf '# Spec\nnothing useful here\n' > "$TEST_DIR/.sf/spec.md"
+
+    run run_validate_spec "$TEST_DIR"
+    [ "$status" -eq 1 ]
+}
+
+@test "script has no syntax error" {
+    run bash -n "$VALIDATE_SPEC_SH"
+    [ "$status" -eq 0 ]
+}

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -3,6 +3,7 @@ name: implement
 description: Implement through pattern learning
 disable-model-invocation: true
 argument-hint: "[--isolate] [SPECIFICATION_OR_PATH]"
+allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/scripts/validate-implementation.sh:*)
 ---
 
 # Implement Command
@@ -38,6 +39,11 @@ Read the current branch. Check whether `.sf/spec.md` exists.
 - Test that it works.
 - Write `.sf/implementation-summary.md`.
 
+**Gate — Post-Implementation:** run `validate-implementation.sh`. The script is at `../../scripts/`
+relative to this skill directory.
+**If validate-implementation.sh fails (non-zero exit), check every criterion the spec meets, or
+finish the work it names. Do not report the implementation as done.**
+
 Output: Implementation + `.sf/implementation-summary.md`
 
 If Step 1 finds no pattern: create the basic file structure the language expects, implement only
@@ -64,3 +70,4 @@ Context arrives for free:
   (request "medium" thoroughness in the prompt).
 - Step 2: Task: implement-minimal with spec: $SPECIFICATION. If ISOLATE is true, add
   isolation: "worktree".
+- Gate: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/validate-implementation.sh ${CLAUDE_PROJECT_DIR:+$CLAUDE_PROJECT_DIR/.sf}`

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -3,7 +3,7 @@ name: spec
 description: Create specifications through parallel analysis
 disable-model-invocation: true
 argument-hint: "[REQUIREMENTS]"
-allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/scripts/spec-dir.sh:*)
+allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/scripts/spec-dir.sh:*), Bash(bash ${CLAUDE_PLUGIN_ROOT}/scripts/validate-spec.sh:*)
 ---
 
 # Spec Command
@@ -11,9 +11,8 @@ allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/scripts/spec-dir.sh:*)
 Creates a specification from requirements. One agent does the steps in order.
 
 ## Usage
-```
-/sf:spec [REQUIREMENTS]
-```
+
+`/sf:spec [REQUIREMENTS]`
 
 ## Context
 
@@ -23,9 +22,8 @@ Check whether `.sf/spec.md` exists.
 ## Clarification Check
 
 If the requirements are vague (fewer than 15 words, or unclear), ask the user before you start.
-Wait for the answer. Do not assume.
+Wait for the answer. Do not assume. Ask about:
 
-**Questions to consider asking:**
 - What specific problem are you solving?
 - Who are the users?
 - What's the desired outcome?
@@ -41,7 +39,6 @@ Pick the mode:
 - `.sf/spec.md` exists → ask the user: "Update existing" / "Create new" → `update` / `new`
 
 Run `spec-dir.sh <first|update|new>`, at `../../scripts/` relative to this skill directory.
-The script finds the project root itself.
 **If spec-dir.sh fails (non-zero exit), halt immediately — do not do the work below.**
 
 ## Execution
@@ -53,6 +50,9 @@ Write each file in turn. The requirements are the input to this skill.
 3. `.sf/research/risks.md` — blockers only, not every possible risk.
 4. `$SF_DIR/spec.md` — merge the three files. Keep it under 50 lines. Use the structure in
    `spec-template.md`, next to this file.
+
+**Gate — Post-Spec:** run `validate-spec.sh`, at `../../scripts/` relative to this skill directory.
+**If it fails (non-zero exit), add the sections it names, then run it again. Do not report done.**
 
 Output: `$SF_DIR/spec.md` (direct file or symlink to timestamped spec)
 
@@ -72,3 +72,4 @@ Context arrives for free:
 - Bash: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/spec-dir.sh $MODE ${CLAUDE_PROJECT_DIR:+$CLAUDE_PROJECT_DIR/.sf}`
 - Batch 1 (Parallel): define-scope, create-criteria, identify-risks — each with requirements: $ARGUMENTS
 - Batch 2: synthesize-spec, following `${CLAUDE_SKILL_DIR}/spec-template.md`
+- Gate: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/validate-spec.sh ${CLAUDE_PROJECT_DIR:+$CLAUDE_PROJECT_DIR/.sf}`

--- a/tests/integration/hooks.bats
+++ b/tests/integration/hooks.bats
@@ -131,9 +131,3 @@ write_impl() {
     run bash -n "$HOOK"
     [ "$status" -eq 0 ]
 }
-
-@test "hook guard uses an explicit if block" {
-    run grep -c 'if \[ ! -f "\$SPEC_FILE" \] || \[ ! -f "\$IMPL_FILE" \]; then exit 0; fi' "$HOOK"
-    [ "$status" -eq 0 ]
-    [ "$output" -eq 1 ]
-}


### PR DESCRIPTION
## Problem

Spec and implementation checks ran only as Claude `Stop` hooks. Both read the Claude hook protocol from stdin and answer with a `block` decision. pi has no hooks, and opencode uses a different plugin model, so on those hosts sf produced specs and implementations that nothing checked.

## Change

- `scripts/validate-spec.sh [sf-dir]` and `scripts/validate-implementation.sh [sf-dir]` (new) hold the checks. They take an artifact directory, print the reason to stderr, and exit non-zero. No stdin.
- The two hooks become adapters: parse the hook JSON, call the script, turn a non-zero exit into `{"decision":"block","reason":...}`. `jq -nc` builds the JSON, so the reason is escaped.
- `skills/spec/SKILL.md` and `skills/implement/SKILL.md` run the matching script as a gate, the same way `skills/document/SKILL.md` runs `doc-gates.sh`.

The directory resolves as argument, then `$SF_DIR`, then `.sf` — the shape `doc-gates.sh` already uses.

## Tests

- `scripts/validate-spec.test.bats` and `scripts/validate-implementation.test.bats` (new) test the plain scripts directly.
- `tests/integration/hooks.bats` still drives the adapter through stdin and asserts the same block conditions. One static test that grepped the hook for a line that moved into the script is gone.
- Full suite passes.

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)