### PR TITLE
docs: state which agent hosts sf supports

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sf",
   "version": "1.3.1",
-  "description": "Claude Code plugin that guides you from requirements to working code — define a spec, implement it, and generate docs, all from your terminal.",
+  "description": "Guides you from requirements to working code — define a spec, implement it, and generate docs, all from your terminal.",
   "author": {
     "name": "Szymon Graczyk",
     "url": "https://github.com/bitcraft-apps"
@@ -12,7 +12,7 @@
   "keywords": [
     "spec-driven development",
     "requirements",
-    "Claude Code plugin",
+    "agent skills",
     "code generation",
     "documentation"
   ]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # spec-first
 
-Write the requirements before you write the code. This Claude Code plugin gives you a workflow with three steps. First, define what to build. Then implement it from the spec. Last, generate the documentation. All steps run in your terminal.
+Write the requirements before you write the code. Spec First gives you a workflow with three steps. First, define what to build. Then implement it from the spec. Last, generate the documentation. All steps run in your terminal.
 
 ## Who is this for
 
-Use this plugin if you want Claude Code to build from clear requirements.
+Use Spec First if you want your coding agent to build from clear requirements.
 
 ## Quick Start
+
+### Claude Code
 
 Add the marketplace. Then install the plugin from your terminal:
 
@@ -32,7 +34,7 @@ git clone https://github.com/bitcraft-apps/spec-first && cd spec-first
 ./scripts/install.sh --dir .agents/skills    # one project only
 ```
 
-Hosts that read this location include pi, opencode, Codex CLI, GitHub Copilot CLI and Gemini CLI. More hosts add support over time. Check the skill documentation of your host for the directories it reads, then pass one with `--dir`.
+See [Supported hosts](#supported-hosts) for the host list.
 
 A checkout installs by symlink. A downloaded release installs by copy. To remove the skills, delete them:
 
@@ -89,7 +91,7 @@ Updated: docs/middleware.md (added rate limiter section)
 
 ## How it works
 
-Each command starts specialized agents. The agents run in parallel when possible. On a host without subagents, one agent does the same steps in order. The spec controls the implement step. Claude Code does not write code without a spec.
+Each command gives the same steps and the same checks to every host. One agent does the steps in order. On Claude Code, specialized subagents run the same steps in parallel. The spec controls the implement step. The agent does not write code without a spec.
 
 ## Token Usage
 
@@ -111,6 +113,12 @@ Your token counts change with the size of the codebase, the complexity of the fe
 | `/sf:implement [--isolate] [SPEC_OR_PATH]` | Build the minimal working solution |
 | `/sf:document [PATHS]` | Generate documentation for the change |
 
-## Requirements
+## Supported hosts
 
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI
+| Host | Install | What runs |
+|------|---------|-----------|
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `claude plugin install sf@spec-first` | The three commands, parallel subagents, and validation hooks |
+| pi, opencode, Codex CLI, GitHub Copilot CLI, Gemini CLI, Cursor, Zed, Amp, Goose, Crush, Kilo Code, Warp, Factory Droid, OpenHands | `./scripts/install.sh` — `.agents/skills` | The three commands in order. The skills call the validation scripts, so the same checks run. |
+| Any other host with a skills directory | `./scripts/install.sh --dir <dir>` | Same as above |
+
+Some hosts read a different directory. Cline, Qwen Code and iFlow CLI need `--dir`. Check the skill documentation of your host for the directories it reads, then pass one with `--dir`.

--- a/docs/technical-reference.md
+++ b/docs/technical-reference.md
@@ -2,11 +2,12 @@
 
 ## Overview
 
-- 3 commands start 13 agent invocations.
+- 3 commands. Each one is a skill that states the steps and the gates for one agent to run in order.
+- On Claude Code, the same 3 commands start 13 agent invocations instead.
 - 7 research agents use the Haiku model.
 - 5 synthesis and implementation agents use the model of the caller.
 - 1 built-in Explore subagent finds patterns.
-- All agents write their output to `.sf/research/`. Git ignores this directory.
+- Every step writes its output to `.sf/research/`. Git ignores this directory.
 
 ## Commands
 
@@ -101,7 +102,12 @@ same checks.
 
 ## Setup
 
-- Claude Code CLI. `Agent` tool support (`subagent_type`) makes the commands run the steps in parallel. Without it, the skills run the same steps in order.
+- A host that reads skills from `.agents/skills`, or from a directory you pass to
+  `scripts/install.sh --dir`. On Claude Code, install the plugin instead.
+- A shell. The skills call the scripts in `scripts/`.
+- Subagents are optional. `Agent` tool support (`subagent_type`) makes the commands run the steps
+  in parallel. Without it, the skills run the same steps in order.
+- Hooks are optional. Only Claude Code loads `hooks/hooks.json`. The skills call the same scripts.
 - Haiku model access for research agents
 - LSP is optional. If LSP is not available, `analyze-implementation` uses Grep and Glob.
 
@@ -141,5 +147,5 @@ bash scripts/validate-plugin.sh
 
 ## Cross-References
 
-- [CLAUDE.md](../CLAUDE.md) — framework philosophy and rules
+- [AGENTS.md](../AGENTS.md) — framework philosophy and rules
 - [CHANGELOG.md](../CHANGELOG.md)


### PR DESCRIPTION
## What

State the supported agent hosts and what each one gets.

- `README.md` — drop the Claude-Code-only identity from the intro and "Who is this for". Split Quick Start into a Claude Code section and an `.agents/skills` section. Replace Requirements with a `Supported hosts` table: host, install path, what runs.
- `docs/technical-reference.md` — the Overview now leads with the sequential path and marks the 13 agent invocations as the Claude Code path. Setup states the host requirement instead of "Claude Code CLI". Cross-reference points at `AGENTS.md`, not `CLAUDE.md`.
- `.claude-plugin/plugin.json` — the description no longer opens with "Claude Code plugin"; the keyword is now `agent skills`.
- `.claude-plugin/marketplace.json` is unchanged. That channel stays Claude-specific.

## Host research

Verified from vendor docs (2026-08-03) as reading `.agents/skills` by default, no config: pi, opencode, Codex CLI, GitHub Copilot CLI, Gemini CLI, Cursor, Zed, Amp, Goose, Crush, Kilo Code, Warp, Factory Droid, OpenHands.

Verified as reading a different directory, so they need `--dir`: Cline, Qwen Code, iFlow CLI. Claude Code also reads only `.claude/skills` — the plugin covers it.

`.agents/skills` is a convention, not a normative part of the Agent Skills specification.

## Test

- `bash scripts/validate-plugin.sh` — 93 passed, 0 failed.
- `./tests/run-tests.sh` — all 158 tests pass.

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)