### PR TITLE
fix: drop allowed-tools from the skills

### DIFF
--- a/docs/technical-reference.md
+++ b/docs/technical-reference.md
@@ -98,7 +98,8 @@ Hook commands use `${CLAUDE_PLUGIN_ROOT}` as a path prefix. At run time, Claude 
 The `Stop` event runs two hooks: validate-spec and validate-implementation. Each hook is an
 adapter. It reads the hook JSON, calls the matching script in `scripts/`, and reports a non-zero
 exit as a `block` decision. The skills call the same scripts, so hosts without hooks get the
-same checks.
+same checks. The skills do not pre-approve these scripts, so the host asks for permission the
+first time each one runs.
 
 ## Setup
 

--- a/skills/document/SKILL.md
+++ b/skills/document/SKILL.md
@@ -3,7 +3,6 @@ name: document
 description: Generate minimal documentation through parallel agents
 disable-model-invocation: true
 argument-hint: "[SPECIFICATION_AND_IMPLEMENTATION_PATHS]"
-allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/scripts/doc-gates.sh:*)
 ---
 
 # Document Command

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -3,7 +3,6 @@ name: implement
 description: Implement through pattern learning
 disable-model-invocation: true
 argument-hint: "[--isolate] [SPECIFICATION_OR_PATH]"
-allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/scripts/validate-implementation.sh:*)
 ---
 
 # Implement Command

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -3,7 +3,6 @@ name: spec
 description: Create specifications through parallel analysis
 disable-model-invocation: true
 argument-hint: "[REQUIREMENTS]"
-allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/scripts/spec-dir.sh:*), Bash(bash ${CLAUDE_PLUGIN_ROOT}/scripts/validate-spec.sh:*)
 ---
 
 # Spec Command

--- a/tests/integration/directory-isolation.bats
+++ b/tests/integration/directory-isolation.bats
@@ -17,9 +17,9 @@ export PROJECT_ROOT
 @test "spec skill includes directory management step" {
     local skill_file="$PROJECT_ROOT/skills/spec/SKILL.md"
 
-    # Check spec skill calls the script and allows the Bash command
+    # Check spec skill calls the script. No allowed-tools: the field is Claude-only.
     grep -q 'scripts/spec-dir.sh \$MODE' "$skill_file"
-    grep -q 'allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/scripts/spec-dir.sh:\*)' "$skill_file"
+    ! grep -q 'allowed-tools' "$skill_file"
 
     # Check it explains directory management workflow
     grep -q "Directory Management" "$skill_file"
@@ -29,7 +29,7 @@ export PROJECT_ROOT
 @test "document skill delegates its gates to doc-gates.sh" {
     local skill_file="$PROJECT_ROOT/skills/document/SKILL.md"
 
-    grep -q 'allowed-tools: Bash(bash ${CLAUDE_PLUGIN_ROOT}/scripts/doc-gates.sh:\*)' "$skill_file"
+    ! grep -q 'allowed-tools' "$skill_file"
     grep -q 'scripts/doc-gates.sh analysis' "$skill_file"
     grep -q 'scripts/doc-gates.sh generation' "$skill_file"
     grep -q 'doc-gates.sh fails.*halt' "$skill_file"


### PR DESCRIPTION
## Problem

Every skill declared `allowed-tools` with `${CLAUDE_PLUGIN_ROOT}` Bash patterns. The value
stated a contract that is false almost everywhere:

- pi reads the field as a space-delimited list. Our value is comma-delimited and names a path
  that never expands there.
- opencode, Codex CLI and Gemini CLI ignore the field.
- `scripts/install.sh` installs into `.agents/skills`. That install is not a plugin, so
  `CLAUDE_PLUGIN_ROOT` is unset and the pattern matches nothing — even in Claude Code.
- The sequential body calls `scripts/spec-dir.sh`, relative to the skill directory. That string
  differs from the pattern, and a permission rule matches strings, not files.

## Fix

Remove the field. The gate scripts now ask for permission on first run, the same way on every
host. One line in the technical reference states this.

`${CLAUDE_PLUGIN_ROOT}` in the `## On Claude Code` sections stays — #219 lists that variable as
Claude-only by nature.

## Test

- `make test` — 158 tests pass.
- `./scripts/validate-plugin.sh` passes, so the frontmatter is still valid.
- `tests/integration/directory-isolation.bats` now asserts the field is gone.

Closes #254
Part of #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)