### PR TITLE
docs: add host skill loading check, fix false test docs

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -14,8 +14,9 @@ The framework uses a **well-organized directory structure** that separates diffe
 tests/
 ├── integration/                 # Integration tests
 │   ├── directory-isolation.bats # Spec directory isolation
-│   ├── framework.bats           # Framework structure tests
+│   ├── dynamic-context.bats     # Shell commands in skill context sections
 │   ├── hooks.bats               # Hook execution and output
+│   ├── plugin.bats              # Plugin structure
 │   ├── plugin-validation.bats   # Plugin artifact validation
 │   └── workflow.bats            # Workflow integration
 │
@@ -28,7 +29,6 @@ tests/
 │   └── environment.bash        # Environment setup
 │
 ├── bats-core/                  # Git submodule - BATS framework
-├── test-helper.bash           # Master helper (loads all modules)
 ├── run-tests.sh               # Intelligent test runner
 └── README.md                  # This documentation
 ```
@@ -115,7 +115,7 @@ cd tests
 ./run-tests.sh --tap                # TAP output for CI
 
 # Run tests directly with BATS
-bats integration/framework.bats     # Single integration test
+bats integration/plugin.bats        # Single integration test
 bats ../scripts/version.test.bats   # Unit test execution
 bats e2e/                           # All E2E tests
 ```
@@ -127,8 +127,9 @@ bats e2e/                           # All E2E tests
 **Purpose**: Test component interactions, plugin artifacts, and workflows
 **Files**:
 - `directory-isolation.bats`: Spec directory isolation
-- `framework.bats`: Framework structure and validation
+- `dynamic-context.bats`: Shell commands embedded in skill Project Context sections
 - `hooks.bats`: Hook execution and output (requires BATS 1.5.0 or later)
+- `plugin.bats`: Plugin structure
 - `plugin-validation.bats`: Plugin artifact validation (requires `python3`)
 - `workflow.bats`: Workflow integration
 
@@ -140,7 +141,14 @@ bats e2e/                           # All E2E tests
 
 ## Helper System
 
-The framework provides a modular helper system in `tests/helpers/`:
+`tests/helpers/` holds three helper modules. **No test loads them today, and no test can.** Each
+module starts with `load 'common'`, and BATS resolves `load` against the directory of the test
+file, not the directory of the helper. A test in `tests/integration/` therefore fails with
+`Could not find .../tests/integration/common`. Every current test file instead sets its own
+`PROJECT_ROOT` and defines its own `setup` and `teardown`. See the test template below.
+
+Fixing the modules means replacing `load 'common'` with a path relative to the module itself.
+Until then, treat this section as an inventory, not as instructions.
 
 ### Core Helper Modules
 
@@ -158,31 +166,10 @@ The framework provides a modular helper system in `tests/helpers/`:
 
 **`environment.bash`**: Test lifecycle management
 - `setup_integration_test()`: Standard integration setup
-- `setup_e2e_test()`: Comprehensive E2E setup  
+- `setup_unit_test()`: Standard unit setup
+- `setup_e2e_test()`: Comprehensive E2E setup
 - `teardown_*()`: Cleanup functions
 - `run_with_timeout()`: Command timeout wrapper
-
-### Usage
-
-**In test files:**
-```bash
-# Load master helper (includes all modules)
-load '../test-helper'
-
-# Use helper functions
-setup() {
-    setup_integration_test
-}
-
-teardown() {
-    teardown_integration_test
-}
-
-@test "example test" {
-    create_mock_home "$TEST_DIR/home"
-    assert_files_exist "$HOME/.claude" "VERSION"
-}
-```
 
 ## Benefits of Organized Structure
 
@@ -214,55 +201,7 @@ teardown() {
 - Backward compatible structure
 - CI/CD integration ready
 
-## Performance Metrics
-
-- **Unit Tests**: ~5-15 seconds (39 tests)
-- **Integration Tests**: ~10-30 seconds (12 tests)  
-- **E2E Tests**: ~30-60 seconds (11 tests)
-- **Full Suite**: ~45-90 seconds (62 tests total)
-- **Parallel Mode**: ~20-40% faster
-
-## Migration from Old Structure
-
-The new organized structure maintains **100% backward compatibility**:
-
-✅ **Existing commands work**:
-- `make test` runs all tests
-- `make test-integration` uses new structure
-- `./run-tests.sh` discovers all organized tests
-
-✅ **Legacy test-helper.bash** loads all new modules
-
-✅ **Collocated unit tests** work from any execution context
-
-✅ **GitHub Actions** updated for new test categories
-    HOME_DIR="$TEST_DIR/home"
-    setup_mock_installation "$HOME_DIR"
-    
-    cd "$HOME_DIR/.claude"
-    run ./utils/version.sh get
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
-}
-```
-
 ## Test Utilities
-
-### Test Helper Functions (`test-helper.bash`)
-
-Common utilities shared across all test suites:
-- **Environment Setup**: Temporary directories and mock installations
-- **Validation Helpers**: Version format checking, output pattern matching
-- **Mock Functions**: Override framework directories for isolated testing
-- **Debugging Tools**: Test failure investigation utilities
-
-**Key Functions:**
-```bash
-create_mock_home()         # Setup isolated installation environment
-is_valid_version()         # Validate semantic version format
-override_framework_dir()   # Redirect framework operations to test directory
-debug_test_failure()       # Debug information for failing tests
-```
 
 ### Test Runner (`run-tests.sh`)
 
@@ -270,7 +209,6 @@ Advanced test execution with multiple options:
 - **Filtering**: Run specific test patterns
 - **Parallel Execution**: Concurrent test execution
 - **Output Formats**: Human-readable or TAP for CI
-- **Legacy Integration**: Run old shell-based tests for comparison
 
 **Command Line Options:**
 ```bash
@@ -283,30 +221,27 @@ Advanced test execution with multiple options:
 
 ## GitHub Actions Integration
 
-### Workflow Structure (`.github/workflows/bats-tests.yml`)
-
-**Multi-Matrix Testing:**
-- **Test Suites**: Parallel execution of different test suites
-- **Cross-Platform**: Ubuntu and macOS testing
-- **Integration Levels**: Unit tests → Integration tests → Full validation
+### Workflow Structure (`.github/workflows/ci.yml`)
 
 **Workflow Jobs:**
-1. **bats-tests**: Matrix execution of individual test suites
-2. **integration-tests**: Complete framework validation
-3. **cross-platform-tests**: Multi-OS compatibility testing
+1. **tests**: Runs `run-tests.sh` over a matrix of `unit`, `integration` and `e2e`
+2. **plugin-validation**: Checks `plugin.json`, `hooks.json`, and that skill and agent files exist
+3. **shellcheck**: Runs ShellCheck over every `*.sh` file outside `bats-core`
+4. **format-checks**: Checks frontmatter fields, agent prompt length, and placeholder text
+
+Every job runs on `ubuntu-latest`.
 
 **Features:**
 - Automatic submodule initialization
 - TAP output for GitHub's test reporting
-- Test result summaries in GitHub UI
-- Failure investigation with detailed logs
+- A `$GITHUB_STEP_SUMMARY` block per matrix leg
 
 ## Development Workflow
 
 ### Writing New Tests
 
 1. **Create Test File**: Use `.bats` extension
-2. **Add Test Helper**: Load common utilities with `load 'test_helper'`
+2. **Set the Project Root**: Derive it from `$BATS_TEST_FILENAME`
 3. **Write Test Functions**: Use `@test "description" { ... }` format
 4. **Use Assertions**: `[ condition ]` for success, check `$status` and `$output`
 5. **Add to Runner**: Update `run-tests.sh` if needed
@@ -315,7 +250,8 @@ Advanced test execution with multiple options:
 ```bash
 #!/usr/bin/env bats
 
-load 'test_helper'
+PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+export PROJECT_ROOT
 
 setup() {
     # Test-specific setup
@@ -353,34 +289,16 @@ The test runner finds `tests/integration/*.bats` automatically. A new file needs
 ### Debugging Failed Tests
 
 1. **Run with Verbose Output**: `make test-verbose`
-2. **Use Debug Helper**: Call `debug_test_failure` in test
-3. **Isolate the Test**: Use filtering to run single test
-4. **Check Environment**: Verify `$PROJECT_ROOT`, `$TEST_DIR` variables
-5. **Manual Execution**: Run commands outside BATS for investigation
+2. **Isolate the Test**: Use filtering to run single test
+3. **Check Environment**: Verify `$PROJECT_ROOT`, `$TEST_DIR` variables
+4. **Manual Execution**: Run commands outside BATS for investigation
 
 ### Best Practices
 
 - **Isolation**: Each test should be independent and cleanup after itself
 - **Descriptive Names**: Test names should clearly describe expected behavior
 - **Setup/Teardown**: Use setup() and teardown() for consistent test environment
-- **Helper Functions**: Extract common patterns to test-helper.bash
 - **Error Messages**: Include context in assertions for easier debugging
-
-## Migration from Legacy Tests
-
-### Legacy Test Support
-
-The old shell-based tests (`integration.sh`, `version.sh`) are preserved for:
-- **Backward Compatibility**: Ensure new BATS tests cover same scenarios
-- **Transition Period**: Gradual migration without losing test coverage
-- **Verification**: Cross-validate BATS results against established tests
-
-### Migration Strategy
-
-1. **Convert Gradually**: Move test cases one-by-one to BATS format
-2. **Run Both**: Execute legacy and BATS tests in parallel during transition
-3. **Validate Equivalence**: Ensure BATS tests catch same issues as legacy tests
-4. **Remove Legacy**: Deprecate shell-based tests once BATS coverage is complete
 
 ## Continuous Integration
 
@@ -396,6 +314,9 @@ make dev-watch             # Auto-run tests on file changes
 make release-check         # Complete test suite for release
 ```
 
+`make release-check` runs only the automated tests. Before a release, also do the
+[Host Skill Loading Check](#host-skill-loading-check) by hand.
+
 ### CI/CD Pipeline
 ```bash
 # CI execution
@@ -406,6 +327,43 @@ make ci-validate           # Plugin validation for CI
 export GITHUB_ACTIONS=true
 cd tests && ./run-tests.sh --tap
 ```
+
+## Host Skill Loading Check
+
+The automated tests check that the install script writes the files. They do not check that a
+host loads the skills. That needs an interactive session. Do this check by hand before a
+release. One host is enough.
+
+1. Install the skills:
+
+   ```bash
+   ./scripts/install.sh
+   ```
+
+2. Start the host. List its skills:
+
+   ```
+   /skills list
+   ```
+
+   Confirm that `spec`, `implement` and `document` appear with their descriptions.
+
+3. Make a throwaway git repository. Run the spec command in it:
+
+   ```
+   /spec add a hello command
+   ```
+
+   Confirm that `.sf/spec.md` appears.
+
+4. Add a row to the table below.
+
+`/skills list` and `/spec` are the Claude Code spellings. Other hosts use their own command
+names. Check the skill documentation of your host.
+
+| sf version | Host | Host version | Date |
+|------------|------|--------------|------|
+|            |      |              |      |
 
 ## Troubleshooting
 
@@ -433,29 +391,14 @@ make clean
 make setup
 ```
 
-**Legacy Test Compatibility:**
-```bash
-# Run legacy tests for comparison
-make test-legacy
-```
-
 ### Getting Help
 
 - **Framework Issues**: Check `./scripts/validate-plugin.sh` output
 - **Version Problems**: Run `./scripts/version.sh info` for diagnostics
-- **Test Debugging**: Use `make test-verbose` and `debug_test_failure()`
+- **Test Debugging**: Use `make test-verbose`
 - **CI Problems**: Check GitHub Actions logs and workflow configuration
 
-## Performance
-
-### Test Execution Times
-
-- **Serial Execution**: ~30-60 seconds for complete suite
-- **Parallel Execution**: ~15-30 seconds with `--parallel`
-- **Individual Suites**: ~5-15 seconds each
-- **CI Execution**: ~2-5 minutes including setup and validation
-
-### Optimization Tips
+## Optimization Tips
 
 - Use `make test-parallel` for faster local development
 - Filter tests during development: `make test FILTER=specific`

--- a/tests/README.md
+++ b/tests/README.md
@@ -330,40 +330,43 @@ cd tests && ./run-tests.sh --tap
 
 ## Host Skill Loading Check
 
-The automated tests check that the install script writes the files. They do not check that a
-host loads the skills. That needs an interactive session. Do this check by hand before a
-release. One host is enough.
+The automated tests check that the install script writes the files. They do not check that a host
+loads them. Do this check by hand before a release.
 
-1. Install the skills:
+**Use an interactive session.** A headless print mode is not a valid substitute. GitHub Copilot
+CLI 0.0.346 in `-p` mode loaded no skill at all, not even a minimal probe skill placed in the
+directory it reads. A pass in print mode therefore proves nothing.
+
+sf reaches hosts by two separate paths. Check the path you changed.
+
+### Plugin path — Claude Code
+
+Claude Code reads `~/.claude/skills`, not `.agents/skills`, and installs sf as a plugin. Do not
+use `install.sh` to check this path.
+
+1. `claude plugin install sf@spec-first`
+2. Start Claude Code. Run `/sf:spec add a hello command` in a throwaway git repository.
+3. Confirm that `.sf/spec.md` appears.
+
+### Skills directory path — every other host
+
+1. Install the skills. Check the skill documentation of your host for the directory it reads,
+   then pass it with `--dir` if it is not `.agents/skills`:
 
    ```bash
-   ./scripts/install.sh
+   ./scripts/install.sh                       # .agents/skills
+   ./scripts/install.sh --dir <host-skill-dir>
    ```
 
-2. Start the host. List its skills:
+2. Start the host interactively. List its skills with the command of that host. Confirm that
+   `spec`, `implement` and `document` appear with their descriptions.
+3. Run the spec command in a throwaway git repository. Confirm that `.sf/spec.md` appears.
 
-   ```
-   /skills list
-   ```
+### Record
 
-   Confirm that `spec`, `implement` and `document` appear with their descriptions.
-
-3. Make a throwaway git repository. Run the spec command in it:
-
-   ```
-   /spec add a hello command
-   ```
-
-   Confirm that `.sf/spec.md` appears.
-
-4. Add a row to the table below.
-
-`/skills list` and `/spec` are the Claude Code spellings. Other hosts use their own command
-names. Check the skill documentation of your host.
-
-| sf version | Host | Host version | Date |
-|------------|------|--------------|------|
-|            |      |              |      |
+| sf version | Path | Host | Host version | Date |
+|------------|------|------|--------------|------|
+|            |      |      |              |      |
 
 ## Troubleshooting
 


### PR DESCRIPTION
Both issues target `tests/README.md`, so they ship together.

## #255 — host skill loading check

#200 verified the install mechanics. It never verified that a host *loads* the skills, because
that needs an interactive session. A bad frontmatter field or a `name` mismatch would break
loading and no test would catch it.

Adds a `## Host Skill Loading Check` section: install, list skills, run `spec` on a throwaway
repository, confirm `.sf/spec.md`. Names the commands, not the intent. One host per release,
recorded in a table.

**The table row is empty.** Steps 2 and 3 need an interactive session and a fresh host start, so
they were not run in this PR. Filling the first row is a release step.

## #230 — GitHub Actions section

The section named `.github/workflows/bats-tests.yml` and three jobs, none of which exist.
Corrected to `ci.yml` with its real jobs: `tests` (matrix over unit, integration, e2e),
`plugin-validation`, `shellcheck`, `format-checks`. Also dropped the "Ubuntu and macOS" claim —
every job is `ubuntu-latest`.

## Other false claims removed

Found while fixing #230, each verified against the tree:

- `tests/test-helper.bash` — does not exist, and no `.bats` file in the repo has a `load` line.
- `create_mock_home`, `is_valid_version`, `override_framework_dir`, `debug_test_failure`,
  `setup_mock_installation` — none exist anywhere.
- `make test-legacy` and the legacy `integration.sh` / `version.sh` migration sections — no such
  target, no such files.
- `framework.bats` — does not exist. `dynamic-context.bats` and `plugin.bats` were missing.
- An orphaned code fragment wedged into "Migration from Old Structure".
- Invented figures ("62 tests total", "~20-40% faster").

The test template now shows the pattern the tests actually use.

## Follow-up

`tests/helpers/*.bash` cannot be loaded by any test — each calls `load 'common'`, which BATS
resolves against the test file directory. Verified with a probe. That is a test change, not a doc
change, so it is filed as #258. This PR states the limitation in the Helper System section
instead of showing a `load` example that fails.

## Verification

- `make test` — 158 tests pass.
- Every `make` target, file path and `.bats` name in the file resolves.
- No residual references to the removed names.

Closes #255
Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)